### PR TITLE
Amended <p> to <h1> and added helptext to password reset template

### DIFF
--- a/ocdaction/ocdaction/templates/registration/password_reset_confirm.html
+++ b/ocdaction/ocdaction/templates/registration/password_reset_confirm.html
@@ -8,7 +8,7 @@
 <section class="container">
     <div class="row">
         <div class="col-xs-12 col-md-offset-4 col-md-4">
-            <p>Set your new password</p>
+            <h1>Set your new password</h1>
             <form class="" role="form" action="" method="POST">
                 {% csrf_token %}
                 {% if form.non_field_errors %}
@@ -28,6 +28,7 @@
                         {% render_field field placeholder=field.label class+="form-control" %}
                     </div>
                 {% endfor %}
+                <p class="helptext">Please choose a strong password or passphrase. Your password must be at least 10 characters long and consist of letters, numbers and other special characters</p>
                 <button type="submit" class="button">Reset</button>
             </form>
         </div>


### PR DESCRIPTION
### ISSUE/TICKET NUMBER
Ticket from Trello "Change Set Your New Password to be an `<h1>` not a `<p>`"

### Describe the changes
- Amended `<p>` to `<h1>` for the "set your new password" text.

- Added help text so that the password rules are displayed

### Screenshots (if appropriate)
<img width="455" alt="screen shot 2017-03-28 at 14 20 41" src="https://cloud.githubusercontent.com/assets/23309660/24409707/e42c0bc4-13c8-11e7-8684-5b310c35ce8e.png">


### Questions or comments (if any)
 This has the help text hardcoded into the template; having looked into it, it'll be fairly involved to pull the help text through from elsewhere (forms etc).