### PR TITLE
Edit task url updated to include text edit

### DIFF
--- a/ocdaction/ocdaction/dashboard_urls.py
+++ b/ocdaction/ocdaction/dashboard_urls.py
@@ -23,7 +23,7 @@ urlpatterns = [
         name="task-add"
     ),
     url(
-        r'^tasks/(?P<task_id>\d+)/$',
+        r'^tasks/(?P<task_id>\d+)/edit$',
         task_edit,
         name="task-edit"
     ),


### PR DESCRIPTION
### ISSUE/TICKET NUMBER
fix for the edit task url 

### Describe the changes
The url ;which was used for edit needed to be used at a later stage, so adding edit after the task_id frees it up

### Screenshots (if appropriate)
Example of url to edit task_d 1
 - Before
http://127.0.0.1:8000/dashboard/tasks/1
 - After
http://127.0.0.1:8000/dashboard/tasks/1/edit

### Questions or comments (if any)
n/a