### PR TITLE
Feature/ses users config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ frontend/.sass-cache/
 frontend/node_modules
 .DS_Store
 **.pyc
+.env

--- a/ocdaction/ocdaction/settings/__init__.py
+++ b/ocdaction/ocdaction/settings/__init__.py
@@ -168,5 +168,8 @@ ACCOUNT_ACTIVATION_DAYS = 7
 REGISTRATION_EMAIL_HTML = True
 REGISTRATION_AUTO_LOGIN = True
 
+EMAIL_BACKEND = 'django_ses.SESBackend'
+REGISTRATION_DEFAULT_FROM_EMAIL = "ocdstage@gmail.com"
+DEFAULT_FROM_EMAIL = 'ocdstage@gmail.com'
 AWS_SES_REGION_NAME = 'us-west-2'
 AWS_SES_REGION_ENDPOINT = 'email.us-west-2.amazonaws.com'

--- a/ocdaction/ocdaction/settings/__init__.py
+++ b/ocdaction/ocdaction/settings/__init__.py
@@ -164,6 +164,9 @@ CONTEXT_PROCESSORS = [
 
 # Registration settings
 ACCOUNT_ACTIVATION_DAYS = 7
-REGISTRATION_DEFAULT_FROM_EMAIL = "info@ocdaction.org"
+#REGISTRATION_DEFAULT_FROM_EMAIL = "info@ocdaction.org"
 REGISTRATION_EMAIL_HTML = True
 REGISTRATION_AUTO_LOGIN = True
+
+AWS_SES_REGION_NAME = 'us-west-2'
+AWS_SES_REGION_ENDPOINT = 'email.us-west-2.amazonaws.com'

--- a/ocdaction/ocdaction/settings/development.py
+++ b/ocdaction/ocdaction/settings/development.py
@@ -5,8 +5,9 @@ SECRET_KEY = 'FAKEforDEV'
 
 DEBUG = True
 
-
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+EMAIL_BACKEND = 'django_ses.SESBackend'
+REGISTRATION_DEFAULT_FROM_EMAIL = "ocdstage@gmail.com"
+DEFAULT_FROM_EMAIL = 'ocdstage@gmail.com'
 
 LOGGING = {
     'version': 1,

--- a/ocdaction/ocdaction/settings/development.py
+++ b/ocdaction/ocdaction/settings/development.py
@@ -5,10 +5,6 @@ SECRET_KEY = 'FAKEforDEV'
 
 DEBUG = True
 
-EMAIL_BACKEND = 'django_ses.SESBackend'
-REGISTRATION_DEFAULT_FROM_EMAIL = "ocdstage@gmail.com"
-DEFAULT_FROM_EMAIL = 'ocdstage@gmail.com'
-
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,3 +10,5 @@ django-custom-user==0.6
 django-registration-redux==1.4
 dj-database-url==0.4.1
 django-widget-tweaks==1.4.1               # Tweaks form field rendering in templates, not in Python
+boto==2.46.1               				  # Sending emails using Amazon SES
+django-ses==0.8.2                         # Sending emails using Amazon SES 

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -11,3 +11,5 @@ pytest-factoryboy==1.3.0   # Factory_Boy integration with pytest fixtures
 pytest-sugar==0.8.0        # For better pytest output
 tox==2.3.2                 # Standardises testing in Python
 pytest-pythonpath==0.7.1   # explicitly setting the project on the python path
+boto==2.46.1               # Sending test emails using Amazon SES
+django-ses==0.8.2          # Sending test emails using Amazon SES 

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -11,5 +11,3 @@ pytest-factoryboy==1.3.0   # Factory_Boy integration with pytest fixtures
 pytest-sugar==0.8.0        # For better pytest output
 tox==2.3.2                 # Standardises testing in Python
 pytest-pythonpath==0.7.1   # explicitly setting the project on the python path
-boto==2.46.1               # Sending test emails using Amazon SES
-django-ses==0.8.2          # Sending test emails using Amazon SES 


### PR DESCRIPTION
### ISSUE/TICKET NUMBER
Setup a test instance of Amazon SES account for staging emails and testing until we have real account access

### Describe the changes
New software to be installed (run pip install -r requirements/base.txt)
and config changes to get AWS emails working
Note: AWS is currently in Sandbox mode, so any email address we wish to send emails to (Register/Password Reset) has to be added to a verified list
Also - below environment variables need to be setup 
AWS_ACCESS_KEY_ID
AWS_SECRET_ACCESS_KEY

### Screenshots (if appropriate)
Add "n/a" if nothing to attach
 - Before
 - After
![screen shot 2017-07-02 at 21 17 47](https://user-images.githubusercontent.com/19981540/27773181-ef5b2f0e-5f6b-11e7-8f84-93ef4a91ed3c.png)


### Questions or comments (if any)
If running Heroku local, the environment variables need to live in .env file in the base folder, and I had to add DJANGO_SETTINGS_MODULE as well to get it working