### PR TITLE
Added additional level to env setting DJANGO_SETTINGS_MODULE

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 machine:
   environment:
     DATABASE_URL: 'sqlite://:memory:'
-    DJANGO_SETTINGS_MODULE: ocdaction.settings.test
+    DJANGO_SETTINGS_MODULE: ocdaction.ocdaction.settings.test
     SECRET_KEY: test-secret-key
     DEBUG: 0
 


### PR DESCRIPTION
### ISSUE/TICKET NUMBER
Circle CI Builds failing

### Describe the changes
Added another level of ocdaction to env variable DJANGO_SETTINGS_MODULE
This will hopefully resolve build error: ImportError: No module named ocdaction.settings.test
However can't tell until it's merged as then will be pushed to CircleCI

### Screenshots (if appropriate)
n/a config change only

### Questions or comments (if any)
n/a config change only