### PR TITLE
Home page displays dashboard when logged in

### DIFF
--- a/ocdaction/core/views.py
+++ b/ocdaction/core/views.py
@@ -1,6 +1,18 @@
 from django.shortcuts import render, redirect
 
 
+def home_index(request):
+    """
+    The Home Index view.
+    """
+
+    template_name = "index.html"
+    if request.user.is_authenticated():
+        return redirect('dashboard-index')
+    else:
+        return render(request, template_name)
+
+
 def dashboard_index(request):
     """
     The Dashboard Index view.

--- a/ocdaction/ocdaction/urls.py
+++ b/ocdaction/ocdaction/urls.py
@@ -5,6 +5,7 @@ from django.conf.urls import url, include
 from django.contrib import admin
 from django.views.generic.base import TemplateView
 
+from core.views import home_index
 
 urlpatterns = [
     url(
@@ -28,7 +29,7 @@ urlpatterns = [
     ),
     url(
         r'^$',
-        TemplateView.as_view(template_name='index.html'),
+        home_index,
         name="index"
     ),
     url(


### PR DESCRIPTION
### ISSUE/TICKET NUMBER
Trello ticket: Logged in user to land on dashboard page not registration page

### Describe the changes
When logged in and visiting the Homepage url, the Dashboard should be displayed
When logged out and visiting the Homepage url, the Homepage should be displayed

### Screenshots (if appropriate)
n/a

### Questions or comments (if any)
n/a