### PR TITLE
Task summary page added

### DIFF
--- a/ocdaction/ocdaction/dashboard_urls.py
+++ b/ocdaction/ocdaction/dashboard_urls.py
@@ -10,7 +10,9 @@ from tasks.views import (
     task_add,
     task_edit,
     task_archive,
-    task_score_form
+    task_score_form,
+    task_complete,
+    task_summary
 )
 
 from core.views import dashboard_index
@@ -47,9 +49,14 @@ urlpatterns = [
         name="task-score-form"
     ),
     url(
-        r'^tasks/complete/$',
-        TemplateView.as_view(template_name="dashboard/act/task_complete.html"),
+        r'^tasks/(?P<task_id>\d+)/complete/(?P<score_id>\d+)/$',
+        task_complete,
         name="task-complete"
+    ),
+    url(
+        r'^tasks/(?P<task_id>\d+)/summary/(?P<score_id>\d+)/$',
+        task_summary,
+        name="task-summary"
     ),
     url(
         r'^index/$',

--- a/ocdaction/ocdaction/dashboard_urls.py
+++ b/ocdaction/ocdaction/dashboard_urls.py
@@ -3,8 +3,6 @@
 """
 from django.conf.urls import url
 
-from django.views.generic import TemplateView
-
 from tasks.views import (
     task_list,
     task_add,

--- a/ocdaction/ocdaction/templates/dashboard/act/task_add.html
+++ b/ocdaction/ocdaction/templates/dashboard/act/task_add.html
@@ -1,16 +1,26 @@
 {% extends "layout.html" %}
 
-{% load static %}
+{% load static widget_tweaks %}
 
 {% block main %}
-    <section>
-        <h1>ACT</h1>
-        <h2>Add new task</h2>
-        <form class="col-xs-6 col-xs-offset-3" method="POST" action="{% url 'task-add' %}">
-            {% csrf_token %}
-            {{ task_form.non_field_errors }}
-            {{ task_form.as_p }}
-            <button class="btn btn-primary pull-left col-xs-2 col-xs-offset-5" type="submit">Save</button>
-        </form>
+	<section class="container">
+	    <div class="row">
+			<div class="col-xs-12">
+				<h1> ACT </h1>
+                <h2>Add new task</h2>
+			</div>
+
+            <form class="col-xs-6 col-xs-offset-3" method="POST" action="{% url 'task-add' %}">
+                {% csrf_token %}
+                {{ task_form.non_field_errors }}
+                {{ task_form.as_p }}
+                <div class="row">
+                    <div class="col-xs-12">
+                        <input class="button col-xs-4" type="submit" value="Save">
+                    </div>
+                </div>
+            </form>
+	    </div>
     </section>
+
 {% endblock %}

--- a/ocdaction/ocdaction/templates/dashboard/act/task_complete.html
+++ b/ocdaction/ocdaction/templates/dashboard/act/task_complete.html
@@ -7,6 +7,6 @@
         <h1>ACT</h1>
         <h2>Tracking Completed</h2>
         <h3>You have completed the task!</h3>
-        <button class="btn btn-primary pull-left col-xs-2 col-xs-offset-5">See how I did</button>
+        <a class="btn btn btn-primary pull-left col-xs-2 col-xs-offset-5" href="{{ anxiety_score_card.get_score_url }}"> See how I did </a>
     </section>
 {% endblock %}

--- a/ocdaction/ocdaction/templates/dashboard/act/task_score_form.html
+++ b/ocdaction/ocdaction/templates/dashboard/act/task_score_form.html
@@ -6,12 +6,12 @@
     <section>
         <h1>ACT</h1>
         <h2>Anxiety Tracker</h2>
-        <form class="col-xs-6 col-xs-offset-3" method="POST" action="{{ form.get_absolute_url }}">
+        <form class="col-xs-6 col-xs-offset-3" method="POST">
             {% csrf_token %}
             <h3> {{ task.task_name }} </h3>
             {{ anxiety_score_form.non_field_errors }}
             {{ anxiety_score_form.as_p }}
-            <button class="btn btn-primary pull-left col-xs-3 col-xs-offset-5" type="submit">Complete the Task</button>
+            <button class="btn btn-primary pull-left col-xs-4 col-xs-offset-5" type="submit">Complete the Task</button>
         </form>
     </section>
 {% endblock %}

--- a/ocdaction/ocdaction/templates/dashboard/act/task_summary.html
+++ b/ocdaction/ocdaction/templates/dashboard/act/task_summary.html
@@ -1,0 +1,18 @@
+{% extends "layout.html" %}
+
+{% load static %}
+
+{% block main %}
+    <section>
+        <h1>ACT</h1>
+        <h2>Your anxiety levels for {{ task.task_name }}</h2>
+        <ul>
+            <li><p>After 0 min: {{ anxiety_score_card.score_after_0_min }}<p></li>
+            <li><p>After 5 min: {{ anxiety_score_card.score_after_5_min }}<p></li>
+            <li><p>After 10 min: {{ anxiety_score_card.score_after_10_min }}<p></li>
+            <li><p>After 15 min: {{ anxiety_score_card.score_after_15_min }}<p></li>
+            <li><p>After 30 min: {{ anxiety_score_card.score_after_30_min }}<p></li>
+            <li><p>After 60 min: {{ anxiety_score_card.score_after_60_min }}<p></li>
+        </ul>
+    </section>
+{% endblock %}

--- a/ocdaction/ocdaction/templates/dashboard/act/task_summary.html
+++ b/ocdaction/ocdaction/templates/dashboard/act/task_summary.html
@@ -2,17 +2,21 @@
 
 {% load static %}
 
-{% block main %}
-    <section>
-        <h1>ACT</h1>
-        <h2>Your anxiety levels for {{ task.task_name }}</h2>
-        <ul>
-            <li><p>After 0 min: {{ anxiety_score_card.score_after_0_min }}<p></li>
-            <li><p>After 5 min: {{ anxiety_score_card.score_after_5_min }}<p></li>
-            <li><p>After 10 min: {{ anxiety_score_card.score_after_10_min }}<p></li>
-            <li><p>After 15 min: {{ anxiety_score_card.score_after_15_min }}<p></li>
-            <li><p>After 30 min: {{ anxiety_score_card.score_after_30_min }}<p></li>
-            <li><p>After 60 min: {{ anxiety_score_card.score_after_60_min }}<p></li>
-        </ul>
-    </section>
-{% endblock %}
+    {% block main %}
+        <section class="container">
+            <h1>ACT</h1>
+            <h2>Your anxiety levels for {{ task.task_name }}</h2>
+                <ul class="col-xs-6 col-xs-offset-3">
+                <li class="row">
+                    <ul>
+                        <li><p>After 0 min: {{ anxiety_score_card.score_after_0_min }}<p></li>
+                        <li><p>After 5 min: {{ anxiety_score_card.score_after_5_min }}<p></li>
+                        <li><p>After 10 min: {{ anxiety_score_card.score_after_10_min }}<p></li>
+                        <li><p>After 15 min: {{ anxiety_score_card.score_after_15_min }}<p></li>
+                        <li><p>After 30 min: {{ anxiety_score_card.score_after_30_min }}<p></li>
+                        <li><p>After 60 min: {{ anxiety_score_card.score_after_60_min }}<p></li>
+                    </ul>
+                </li>
+                </ul>
+        </section>
+    {% endblock %}

--- a/ocdaction/tasks/models.py
+++ b/ocdaction/tasks/models.py
@@ -29,7 +29,7 @@ class Task(models.Model):
         self.save()
 
 class AnxietyScoreCard(models.Model):
-    """ 
+    """
     Anxiety score card is a collection of scores for the task
     """
     SCORE_ZERO = '0'
@@ -92,7 +92,14 @@ class AnxietyScoreCard(models.Model):
 
     def user_name(self):
         return self.task.user
-    
+
     def get_absolute_url(self):
-        return reverse('task_score_form',
-                        kwargs={'task_id': self.task})
+        return reverse(
+            'task-score-form',
+            kwargs={'task_id': self.task.id})
+
+    def get_score_url(self):
+        return reverse(
+            'task-summary',
+            kwargs={'task_id': self.task.id,
+                    'score_id': self.id})

--- a/ocdaction/tasks/views.py
+++ b/ocdaction/tasks/views.py
@@ -18,9 +18,9 @@ def task_list(request, archived=None):
     else:
         tasks = Task.objects.filter(user=request.user, is_archived=True).order_by('-created_at', '-updated_at')[:10]
         context = {'tasks': tasks, 'archived': True}
-        
+
     return render(request, template_name, context)
-    
+
 
 @login_required
 def task_add(request):
@@ -83,8 +83,44 @@ def task_archive(request, task_id):
     """
     task = get_object_or_404(Task, pk=task_id)
     task.archive()
-    
+
     return redirect('task-list')
+
+
+@login_required
+def task_complete(request, task_id, score_id):
+    """
+    Mark task completed
+    """
+    task = get_object_or_404(Task, pk=task_id)
+    anxiety_score_card = get_object_or_404(AnxietyScoreCard, pk=score_id)
+
+    return render(
+        request,
+        'dashboard/act/task_complete.html',
+        {
+            'task': task,
+            'anxiety_score_card': anxiety_score_card,
+        }
+    )
+
+
+@login_required
+def task_summary(request, task_id, score_id):
+    """
+    Summary of a task
+    """
+    task = get_object_or_404(Task, pk=task_id)
+    anxiety_score_card = get_object_or_404(AnxietyScoreCard, pk=score_id)
+
+    return render(
+        request,
+        'dashboard/act/task_summary.html',
+        {
+            'task': task,
+            'anxiety_score_card': anxiety_score_card,
+        }
+    )
 
 
 @login_required
@@ -101,10 +137,10 @@ def task_score_form(request, task_id):
             anxiety_score_card.task = task
             anxiety_score_card.save()
 
-            return redirect('task-complete')
+            return redirect('task-complete', task_id=task.id, score_id=anxiety_score_card.id)
     else:
         anxiety_score_form = AnxietyScoreCardForm()
-    
+
     return render(
         request,
         'dashboard/act/task_score_form.html',


### PR DESCRIPTION
### ISSUE/TICKET NUMBER
Trello ticket: Task summary page showing anxiety levels after completing the task

### Describe the changes
Task summary page added which shows anxiety levels after a task completed. 
To get this working also needed to pass the score id through from task score form (where it's created) and through task completed form.

### Screenshots (if appropriate)
New page added below

![screen shot 2017-07-28 at 21 08 16](https://user-images.githubusercontent.com/19981540/28734641-e042ed22-73d9-11e7-8486-3e41e848e0a8.png)

### Questions or comments (if any)
In the url from the below attachment you can see the score_id is now also passed through (44 in this example). This is required as we are interested in displaying the task summary page which relates to the task just performed (as a task can be performed multiple times)

![screen shot 2017-07-28 at 21 08 04](https://user-images.githubusercontent.com/19981540/28734682-05ec2a66-73da-11e7-929e-fc1301a6d1dd.png)
 