### PR TITLE
Date of Birth defaults to 20 years ago

### DIFF
--- a/ocdaction/profiles/forms.py
+++ b/ocdaction/profiles/forms.py
@@ -20,8 +20,9 @@ class OCDActionUserRegistrationForm(RegistrationForm):
 
     now = datetime.datetime.now()
     current_year = now.year
+    users_average_age = 20
     date_birth = forms.DateField(widget=forms.SelectDateWidget(
-        years=range(current_year - 100, current_year)),
+        years=range(current_year - users_average_age, current_year)),
         label='Date of birth'
     )
 


### PR DESCRIPTION
### ISSUE/TICKET NUMBER
Trello ticket: Change a default year in dob to reflect the av age of users

### Describe the changes
Users Date of Birth changed to default to Average age of users (20)

### Screenshots (if appropriate)
 - After

![screen shot 2017-07-29 at 09 40 28](https://user-images.githubusercontent.com/19981540/28743452-fe6d3042-7441-11e7-890f-c86eb913044d.png)

### Questions or comments (if any)
n/a