### PR TITLE
Archive challenge - prompt user with confirmation msg before archiving

### DIFF
--- a/ocdaction/ocdaction/templates/dashboard/act/task_list.html
+++ b/ocdaction/ocdaction/templates/dashboard/act/task_list.html
@@ -30,7 +30,7 @@
                         <li><p>Compulsions: My task compulsions are {{ task.task_compulsions }}<p></li>
                     </ul>
                     {% if not archived %}
-                        <a class="btn btn-primary pull-left col-xs-2 col-xs-offset-1" href="{% url 'task-archive' task.id %}">Archive</a>
+                        <a class="btn btn-primary pull-left col-xs-2 col-xs-offset-1 js-confirm-archive" href="{% url 'task-archive' task.id %}" onclick="return confirm('Are you sure want to archive this challenge? You will not be able to reactivate it.')";>Archive</a>
                         <a class="btn btn-primary pull-right col-xs-3" href="{% url 'task-score-form' task.id %}"> Do the task </a>
                     {% endif %}   
                 </li>

--- a/ocdaction/ocdaction/templates/dashboard/act/task_list.html
+++ b/ocdaction/ocdaction/templates/dashboard/act/task_list.html
@@ -30,7 +30,7 @@
                         <li><p>Compulsions: My task compulsions are {{ task.task_compulsions }}<p></li>
                     </ul>
                     {% if not archived %}
-                        <a class="btn btn-primary pull-left col-xs-2 col-xs-offset-1 js-confirm-archive" href="{% url 'task-archive' task.id %}" onclick="return confirm('Are you sure want to archive this challenge? You will not be able to reactivate it.')";>Archive</a>
+                        <a class="btn btn-primary pull-left col-xs-2 col-xs-offset-1" href="{% url 'task-archive' task.id %}" onclick="return checkArchive()";>Archive</a>
                         <a class="btn btn-primary pull-right col-xs-3" href="{% url 'task-score-form' task.id %}"> Do the task </a>
                     {% endif %}   
                 </li>
@@ -45,4 +45,14 @@
             </a>
         {% endif %}
     </section>
+    
+    <script language="javascript">
+        function checkArchive() {
+            if (confirm("Are you sure you want to archive this task? Once archived you will not be able to reactivate it.")) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+    </script>
 {% endblock %}


### PR DESCRIPTION
### ISSUE/TICKET NUMBER
[Archive challenge]()

### Describe the changes
Prompt user with confirmation msg before archiving

### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/19479903/30826349-3a8cf1f6-a22e-11e7-93c3-81946b292d56.png)

### Questions or comments (if any)
I found this solution on stackoverflow, it's very compact, but I'm not sure if it's best practice or if I should find a way to abstract it to js file? 