### PR TITLE
Add dummy backend email service for dev environment

### DIFF
--- a/ocdaction/ocdaction/settings/development.py
+++ b/ocdaction/ocdaction/settings/development.py
@@ -5,6 +5,8 @@ SECRET_KEY = 'FAKEforDEV'
 
 DEBUG = True
 
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,


### PR DESCRIPTION
### ISSUE/TICKET NUMBER
Email service for dev environment 

### Describe the changes
We need email service to register/reset password locally. This PR adds generic email service to development settings.

### Screenshots (if appropriate)
n/a

### Questions or comments (if any)

Please note the CI will fail because of psycopg2. Upgrade is included in: https://github.com/womenhackfornonprofits/ocdaction/pull/102