### PR TITLE
Move archive link to the top navigation menu

### DIFF
--- a/ocdaction/challenges/urls.py
+++ b/ocdaction/challenges/urls.py
@@ -5,6 +5,7 @@ from django.conf.urls import url
 
 from .views import (
     challenge_list,
+    challenge_list_archived,
     challenge_add,
     challenge_edit,
     challenge_archive,
@@ -20,8 +21,8 @@ urlpatterns = [
         name="challenge-list"
     ),
     url(
-        r'^(?P<archived>)archived/$',
-        challenge_list,
+        r'^archived/$',
+        challenge_list_archived,
         name="challenge-list-archived"
     ),
     url(

--- a/ocdaction/challenges/views.py
+++ b/ocdaction/challenges/views.py
@@ -17,6 +17,17 @@ def challenge_list(request, archived=None):
 
 
 @login_required
+def challenge_list_archived(request, archived=True):
+    """
+    Displays a list of user archived challenges
+    """ 
+    challenges = Challenge.objects.filter(user=request.user, is_archived=True).order_by('-created_at', '-updated_at')[:10]
+    context = {'challenges': challenges}
+
+    return render(request, 'challenge/challenge_list_archived.html', context)
+
+
+@login_required
 def challenge_add(request):
     """
     Add a new challenge

--- a/ocdaction/challenges/views.py
+++ b/ocdaction/challenges/views.py
@@ -8,18 +8,12 @@ from challenges.forms import ChallengeForm, AnxietyScoreCardForm
 @login_required
 def challenge_list(request, archived=None):
     """
-    Displays a list os user challenges on ACT view
+    Displays a list of user challenges on Challenge view
     """
-    template_name = "challenge/challenge_list.html"
+    challenges = Challenge.objects.filter(user=request.user, is_archived=False).order_by('-created_at', '-updated_at')[:10]
+    context = {'challenges': challenges}
 
-    if archived == None:
-        challenges = Challenge.objects.filter(user=request.user, is_archived=False).order_by('-created_at', '-updated_at')[:10]
-        context = {'challenges': challenges}
-    else:
-        challenges = Challenge.objects.filter(user=request.user, is_archived=True).order_by('-created_at', '-updated_at')[:10]
-        context = {'challenges': challenges, 'archived': True}
-
-    return render(request, template_name, context)
+    return render(request, 'challenge/challenge_list.html', context)
 
 
 @login_required

--- a/ocdaction/challenges/views.py
+++ b/ocdaction/challenges/views.py
@@ -6,7 +6,7 @@ from challenges.forms import ChallengeForm, AnxietyScoreCardForm
 
 
 @login_required
-def challenge_list(request, archived=None):
+def challenge_list(request):
     """
     Displays a list of user challenges on Challenge view
     """
@@ -17,7 +17,7 @@ def challenge_list(request, archived=None):
 
 
 @login_required
-def challenge_list_archived(request, archived=True):
+def challenge_list_archived(request):
     """
     Displays a list of user archived challenges
     """ 

--- a/ocdaction/ocdaction/templates/challenge/challenge_list.html
+++ b/ocdaction/ocdaction/templates/challenge/challenge_list.html
@@ -4,46 +4,28 @@
 
 {% block main %}
     <section class="container">
-        <h1>ACT</h1>
-        {% if archived %}
-            <h2>Your archived challenges</h2>
-            <a class="btn btn-primary pull-left col-xs-2 col-xs-offset-5" href="{% url 'challenge-list' %}">Back to challenges
-            </a>
-        {% else %}
-            <h2>All your challenges</h2>
-            <a class="btn btn-primary pull-left col-xs-2 col-xs-offset-5" href="{% url 'challenge-list-archived' archived %}">
-                <span class="fa fa-archive"></span> View Archived Challenges
-            </a>
-        {% endif %}
+        <h2>All your challenges</h2>
         {% if challenges %}
             {% for challenge in challenges %}
                 <ul class="col-xs-6 col-xs-offset-3">
-                <li class="row">
-                    {% if archived %}
-                        <h3>{{ challenge.challenge_name }}</h3>
-                    {% else %}
+                    <li class="row">
                         <a href="{% url 'challenge-edit' challenge.id %}"><h3>{{ challenge.challenge_name }}</h3></a>                 
-                    {% endif %}
-                    <ul>
-                        <li><p>Fears: My challenge fears are {{ challenge.challenge_fears }}<p></li>
-                        <li><p>Goals: My challenge goals are {{ challenge.challenge_goals }}<p></li>
-                        <li><p>Compulsions: My challenge compulsions are {{ challenge.challenge_compulsions }}<p></li>
-                    </ul>
-                    {% if not archived %}
+                        <ul>
+                            <li><p>Fears: My challenge fears are {{ challenge.challenge_fears }}<p></li>
+                            <li><p>Goals: My challenge goals are {{ challenge.challenge_goals }}<p></li>
+                            <li><p>Compulsions: My challenge compulsions are {{ challenge.challenge_compulsions }}<p></li>
+                        </ul>
                         <a class="btn btn-primary pull-left col-xs-2 col-xs-offset-1" href="{% url 'challenge-archive' challenge.id %}" onclick="return checkArchive()";>Archive</a>
                         <a class="btn btn-primary pull-right col-xs-3" href="{% url 'challenge-score-form' challenge.id %}"> Do the challenge </a>
-                    {% endif %}   
-                </li>
+                    </li>
                 </ul>
             {% endfor %}
         {% else %}
             <h2>You have no challenges yet!</h2>
         {% endif %}
-        {% if not archived %}
-            <a class="btn btn-primary pull-left col-xs-2 col-xs-offset-5" href="{% url 'challenge-add' %}">
-                <span class="fa fa-plus-square"></span> Add New Challenge
-            </a>
-        {% endif %}
+        <a class="btn btn-primary pull-left col-xs-2 col-xs-offset-5" href="{% url 'challenge-add' %}">
+            <span class="fa fa-plus-square"></span> Add New Challenge
+        </a>
     </section>
     
     <script language="javascript">

--- a/ocdaction/ocdaction/templates/challenge/challenge_list_archived.html
+++ b/ocdaction/ocdaction/templates/challenge/challenge_list_archived.html
@@ -1,0 +1,25 @@
+{% extends "layout.html" %}
+
+{% load static %}
+
+{% block main %}
+    <section class="container">
+        <h2>My Archive</h2>
+        {% if challenges %}
+            {% for challenge in challenges %}
+                <ul class="col-xs-6 col-xs-offset-3">
+                    <li class="row">
+                        <h3>{{ challenge.challenge_name }}</h3>                        
+                        <ul>
+                            <li><p>Fears: My challenge fears are {{ challenge.challenge_fears }}<p></li>
+                            <li><p>Goals: My challenge goals are {{ challenge.challenge_goals }}<p></li>
+                            <li><p>Compulsions: My challenge compulsions are {{ challenge.challenge_compulsions }}<p></li>
+                        </ul>
+                    </li>
+                </ul>
+            {% endfor %}
+        {% else %}
+            <h2>You have no archived challenges yet</h2>
+        {% endif %}
+    </section>
+{% endblock %}

--- a/ocdaction/ocdaction/templates/layout.html
+++ b/ocdaction/ocdaction/templates/layout.html
@@ -20,7 +20,10 @@
 				        <li class="header__item">
 				            <a class="header__link" href="{% url 'contact' %}">Contact</a>
 				        </li>
-				        {% if user.is_authenticated %}
+						{% if user.is_authenticated %}
+						<li class="header__item">
+							<a class="header__link" href="{% url 'challenge-list-archived' %}">Archive</a>
+						</li>
 					        <li class="header__item">
 								<a href="{% url 'logout' %}">
 									<i class="fa fa-sign-out"></i> Log out


### PR DESCRIPTION
### Describe the changes
For the better UX we want the user to be able to navigate easily between the current and archived challenges (old tasks):

- move Archived tasks link from Challenge list page to the top menu
- to be visible only to logged in users
