### PR TITLE
Challenge view page

### DIFF
--- a/ocdaction/challenges/urls.py
+++ b/ocdaction/challenges/urls.py
@@ -7,6 +7,7 @@ from .views import (
     challenge_list,
     challenge_list_archived,
     challenge_add,
+    challenge_view,
     challenge_edit,
     challenge_archive,
     challenge_score_form,
@@ -31,7 +32,12 @@ urlpatterns = [
         name="challenge-add"
     ),
     url(
-        r'^(?P<challenge_id>\d+)/edit$',
+        r'^(?P<challenge_id>\d+)/$',
+        challenge_view,
+        name="challenge"
+    ),
+    url(
+        r'^(?P<challenge_id>\d+)/edit/$',
         challenge_edit,
         name="challenge-edit"
     ),

--- a/ocdaction/challenges/urls.py
+++ b/ocdaction/challenges/urls.py
@@ -41,7 +41,7 @@ urlpatterns = [
         name="challenge-archive"
     ),
     url(
-        r'^(?P<challenge_id>\d+)/$',
+        r'^(?P<challenge_id>\d+)/exposure/$',
         challenge_score_form,
         name="challenge-score-form"
     ),

--- a/ocdaction/challenges/views.py
+++ b/ocdaction/challenges/views.py
@@ -52,6 +52,16 @@ def challenge_add(request):
         }
     )
 
+@login_required
+def challenge_view(request, challenge_id):
+    """
+    View a challenge
+    """
+    challenge = get_object_or_404(Challenge, pk=challenge_id)
+    context = {'challenge': challenge}
+
+    return render(request, 'challenge/challenge_view.html', context)
+
 
 @login_required
 def challenge_edit(request, challenge_id):
@@ -68,7 +78,9 @@ def challenge_edit(request, challenge_id):
             challenge.user = request.user
             challenge.save()
 
-            return redirect('challenge-list')
+            context = {'challenge': challenge_inst}
+            return render(request, 'challenge/challenge_view.html', context)
+        
     else:
         challenge_form = ChallengeForm(instance=challenge_inst)
 

--- a/ocdaction/ocdaction/templates/challenge/challenge_list.html
+++ b/ocdaction/ocdaction/templates/challenge/challenge_list.html
@@ -4,18 +4,15 @@
 
 {% block main %}
     <section class="container">
-        <h2>All your challenges</h2>
+        <h2>My Challenge Hierarchy</h2>
+        <a class="btn btn-primary pull-left col-xs-2 col-xs-offset-5" href="{% url 'challenge-add' %}">
+            <span class="fa fa-plus-square"></span> Add New Challenge
+        </a>
         {% if challenges %}
             {% for challenge in challenges %}
                 <ul class="col-xs-6 col-xs-offset-3">
                     <li class="row">
-                        <a href="{% url 'challenge-edit' challenge.id %}"><h3>{{ challenge.challenge_name }}</h3></a>                 
-                        <ul>
-                            <li><p>Fears: My challenge fears are {{ challenge.challenge_fears }}<p></li>
-                            <li><p>Goals: My challenge goals are {{ challenge.challenge_goals }}<p></li>
-                            <li><p>Compulsions: My challenge compulsions are {{ challenge.challenge_compulsions }}<p></li>
-                        </ul>
-                        <a class="btn btn-primary pull-left col-xs-2 col-xs-offset-1" href="{% url 'challenge-archive' challenge.id %}" onclick="return checkArchive()";>Archive</a>
+                        <a href="{% url 'challenge' challenge.id %}"><h3>{{ challenge.challenge_name }}</h3></a>                 
                         <a class="btn btn-primary pull-right col-xs-3" href="{% url 'challenge-score-form' challenge.id %}"> Do the challenge </a>
                     </li>
                 </ul>
@@ -23,18 +20,5 @@
         {% else %}
             <h2>You have no challenges yet!</h2>
         {% endif %}
-        <a class="btn btn-primary pull-left col-xs-2 col-xs-offset-5" href="{% url 'challenge-add' %}">
-            <span class="fa fa-plus-square"></span> Add New Challenge
-        </a>
-    </section>
-    
-    <script language="javascript">
-        function checkArchive() {
-            if (confirm("Are you sure you want to archive this challenge? Once archived you will not be able to reactivate it.")) {
-                return true;
-            } else {
-                return false;
-            }
-        }
-    </script>
+    </section>    
 {% endblock %}

--- a/ocdaction/ocdaction/templates/challenge/challenge_view.html
+++ b/ocdaction/ocdaction/templates/challenge/challenge_view.html
@@ -1,0 +1,34 @@
+{% extends "layout.html" %}
+
+{% load static %}
+
+{% block main %}
+    <section class="container">
+        <h2>{{ challenge.challenge_name }}</h2>
+            <ul class="col-xs-6 col-xs-offset-3">
+                <li><p>Fears: My challenge fears are {{ challenge.challenge_fears }}<p></li>
+                <li><p>Goals: My challenge goals are {{ challenge.challenge_goals }}<p></li>
+                <li><p>Compulsions: My challenge compulsions are {{ challenge.challenge_compulsions }}<p></li>
+                <li>
+                    <a class="btn btn-primary pull-right col-xs-2 col-xs-offset-1" 
+                        href="{% url 'challenge-edit' challenge.id %}">
+                        Edit
+                    </a>    
+                    <a class="btn btn-primary pull-left col-xs-2 col-xs-offset-1" 
+                        href="{% url 'challenge-archive' challenge.id %}" onclick="return checkArchive()";>
+                        Archive
+                    </a>
+                </li>
+            </ul>
+    </section>
+
+    <script language="javascript">
+        function checkArchive() {
+            if (confirm("Are you sure you want to archive this challenge? Once archived you will not be able to reactivate it.")) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+    </script>
+{% endblock %}


### PR DESCRIPTION
### Describe the changes
_Background: Currently a challenge list page is very cluttered with displaying too many details about each challenge. We want to move those to a new page that will display all necessary challenge details_

- add a challenge view page with archive and edit actions
- in a challenges hierarchy (list) page leave only challenge title and an exposure button
- after editing a challenge redirect back to a challenge view page

This PR doesn't cover new design implementation

### Screenshots (if appropriate)
 - Before

<img width="790" alt="screen shot 2017-11-10 at 14 37 48" src="https://user-images.githubusercontent.com/5237879/32663158-d8073d0a-c624-11e7-8c4f-d6e75fc70fd1.png">

- After

<img width="1221" alt="screen shot 2017-11-10 at 14 36 27" src="https://user-images.githubusercontent.com/5237879/32663164-de3b8014-c624-11e7-85ae-b67da5b1d130.png">
<img width="1159" alt="screen shot 2017-11-10 at 14 36 45" src="https://user-images.githubusercontent.com/5237879/32663166-e14f7f3a-c624-11e7-9512-91cac5f3c916.png">

