### PR TITLE
Move archived challenge details to a challenge view page

### DIFF
--- a/ocdaction/ocdaction/templates/challenge/challenge_list_archived.html
+++ b/ocdaction/ocdaction/templates/challenge/challenge_list_archived.html
@@ -9,12 +9,7 @@
             {% for challenge in challenges %}
                 <ul class="col-xs-6 col-xs-offset-3">
                     <li class="row">
-                        <h3>{{ challenge.challenge_name }}</h3>                        
-                        <ul>
-                            <li><p>Fears: My challenge fears are {{ challenge.challenge_fears }}<p></li>
-                            <li><p>Goals: My challenge goals are {{ challenge.challenge_goals }}<p></li>
-                            <li><p>Compulsions: My challenge compulsions are {{ challenge.challenge_compulsions }}<p></li>
-                        </ul>
+                        <a href="{% url 'challenge' challenge.id %}"><h3>{{ challenge.challenge_name }}</h3></a>
                     </li>
                 </ul>
             {% endfor %}

--- a/ocdaction/ocdaction/templates/challenge/challenge_view.html
+++ b/ocdaction/ocdaction/templates/challenge/challenge_view.html
@@ -9,6 +9,7 @@
                 <li><p>Fears: My challenge fears are {{ challenge.challenge_fears }}<p></li>
                 <li><p>Goals: My challenge goals are {{ challenge.challenge_goals }}<p></li>
                 <li><p>Compulsions: My challenge compulsions are {{ challenge.challenge_compulsions }}<p></li>
+                {% if not challenge.is_archived %}
                 <li>
                     <a class="btn btn-primary pull-right col-xs-2 col-xs-offset-1" 
                         href="{% url 'challenge-edit' challenge.id %}">
@@ -19,6 +20,7 @@
                         Archive
                     </a>
                 </li>
+                {% endif %}
             </ul>
     </section>
 


### PR DESCRIPTION
Same behaviour as for a challenge view page, except we don't show 'edit' nor 'archive' buttons.