### PR TITLE
Challenge list with levels

### DIFF
--- a/ocdaction/challenges/models.py
+++ b/ocdaction/challenges/models.py
@@ -41,7 +41,7 @@ class Challenge(models.Model):
             latest_initial_anxiety_level = anxiety_score_card.anxiety_at_0_min
         except:
             AnxietyScoreCard.DoesNotExist
-            latest_initial_anxiety_level = 0
+            latest_initial_anxiety_level = -1
         return latest_initial_anxiety_level
 
     def get_latest_initial_anxiety_level_as_str(self):

--- a/ocdaction/challenges/models.py
+++ b/ocdaction/challenges/models.py
@@ -44,15 +44,6 @@ class Challenge(models.Model):
             latest_initial_anxiety_level = -1
         return latest_initial_anxiety_level
 
-    def get_latest_initial_anxiety_level_as_str(self):
-        try:
-            anxiety_score_card = AnxietyScoreCard.objects.filter(challenge=self).last()
-            latest_initial_anxiety_level = anxiety_score_card.anxiety_at_0_min
-        except:
-            AnxietyScoreCard.DoesNotExist
-            latest_initial_anxiety_level = "-"
-        return latest_initial_anxiety_level
-
 class AnxietyScoreCard(models.Model):
     """
     Anxiety score card is a collection of scores for the challenge

--- a/ocdaction/challenges/models.py
+++ b/ocdaction/challenges/models.py
@@ -41,9 +41,17 @@ class Challenge(models.Model):
             latest_initial_anxiety_level = anxiety_score_card.anxiety_at_0_min
         except:
             AnxietyScoreCard.DoesNotExist
-            latest_initial_anxiety_level = "-"
+            latest_initial_anxiety_level = 0
         return latest_initial_anxiety_level
 
+    def get_latest_initial_anxiety_level_as_str(self):
+        try:
+            anxiety_score_card = AnxietyScoreCard.objects.filter(challenge=self).last()
+            latest_initial_anxiety_level = anxiety_score_card.anxiety_at_0_min
+        except:
+            AnxietyScoreCard.DoesNotExist
+            latest_initial_anxiety_level = "-"
+        return latest_initial_anxiety_level
 
 class AnxietyScoreCard(models.Model):
     """

--- a/ocdaction/challenges/models.py
+++ b/ocdaction/challenges/models.py
@@ -35,6 +35,15 @@ class Challenge(models.Model):
         self.is_archived = True
         self.save()
 
+    def get_latest_initial_anxiety_level(self):
+        try:
+            anxiety_score_card = AnxietyScoreCard.objects.filter(challenge=self).last()
+            latest_initial_anxiety_level = anxiety_score_card.anxiety_at_0_min
+        except:
+            AnxietyScoreCard.DoesNotExist
+            latest_initial_anxiety_level = "-"
+        return latest_initial_anxiety_level
+
 
 class AnxietyScoreCard(models.Model):
     """

--- a/ocdaction/challenges/views.py
+++ b/ocdaction/challenges/views.py
@@ -16,7 +16,8 @@ def challenge_list(request):
         '-updated_at'
     )[:10]
 
-    sorted_challenges = sorted(challenges.all(), reverse=True, key = lambda c: int(c.get_latest_initial_anxiety_level()))
+    sorted_challenges_by_anxiety = sorted(challenges.all(), reverse=True, key = lambda c: int(c.get_latest_initial_anxiety_level()))
+    sorted_challenges = sorted(sorted_challenges_by_anxiety, reverse=True, key = lambda c: c.in_progress)
 
     challenge_in_progress = Challenge.objects.filter(in_progress=True)
     anxiety_score_card = AnxietyScoreCard.objects.filter(challenge=challenge_in_progress).last()

--- a/ocdaction/challenges/views.py
+++ b/ocdaction/challenges/views.py
@@ -10,11 +10,23 @@ def challenge_list(request):
     """
     Displays a list of user challenges on Challenge view
     """
-    challenges = Challenge.objects.filter(user=request.user, is_archived=False).order_by('-in_progress', '-created_at', '-updated_at')[:10]
+    challenges = Challenge.objects.filter(user=request.user, is_archived=False).order_by(
+        '-in_progress',
+        '-created_at',
+        '-updated_at'
+    )[:10]
+
+    sorted_challenges = sorted(challenges.all(), reverse=True, key = lambda c: int(c.get_latest_initial_anxiety_level()))
+
     challenge_in_progress = Challenge.objects.filter(in_progress=True)
     anxiety_score_card = AnxietyScoreCard.objects.filter(challenge=challenge_in_progress).last()
 
-    context = {'challenges': challenges, 'another_challenge_in_progress': challenge_in_progress, 'anxiety_score_card': anxiety_score_card}
+    context = {
+        'challenges': challenges,
+        'sorted_challenges': sorted_challenges,
+        'another_challenge_in_progress': challenge_in_progress,
+        'anxiety_score_card': anxiety_score_card
+    }
 
     return render(request, 'challenge/challenge_list.html', context)
 

--- a/ocdaction/ocdaction/templates/challenge/challenge_list.html
+++ b/ocdaction/ocdaction/templates/challenge/challenge_list.html
@@ -9,7 +9,7 @@
             <span class="fa fa-plus-square"></span> Add New Challenge
         </a>
         {% if challenges %}
-            {% for challenge in challenges %}
+            {% for challenge in sorted_challenges %}
                 {% if challenge.in_progress %}
                 <ul class="col-xs-6 col-xs-offset-3">
                     <h4>In progress</h4>
@@ -23,7 +23,7 @@
                     {% if another_challenge_in_progress %}
                         <ul class="col-xs-6 col-xs-offset-3">
                             <li class="row">
-                                Level: {{ challenge.get_latest_initial_anxiety_level }}
+                                Level: {{ challenge.get_latest_initial_anxiety_level_as_str }}
                                 <a href="{% url 'challenge' challenge.id %}"><h3>{{ challenge.challenge_name }}</h3></a>
                                 <button class="btn btn-primary pull-right col-xs-3" disabled> Do the challenge </button>
                             </li>
@@ -31,7 +31,7 @@
                     {% else %}
                         <ul class="col-xs-6 col-xs-offset-3">
                             <li class="row">
-                                Level: {{ challenge.get_latest_initial_anxiety_level }}
+                                Level: {{ challenge.get_latest_initial_anxiety_level_as_str }}
                                 <a href="{% url 'challenge' challenge.id %}"><h3>{{ challenge.challenge_name }}</h3></a>
                                 <a class="btn btn-primary pull-right col-xs-3" href="{% url 'challenge-score-form-new' challenge.id %}"> Do the challenge </a>
                             </li>

--- a/ocdaction/ocdaction/templates/challenge/challenge_list.html
+++ b/ocdaction/ocdaction/templates/challenge/challenge_list.html
@@ -23,7 +23,11 @@
                     {% if another_challenge_in_progress %}
                         <ul class="col-xs-6 col-xs-offset-3">
                             <li class="row">
-                                Level: {{ challenge.get_latest_initial_anxiety_level_as_str }}
+                                Level:  {% if challenge.get_latest_initial_anxiety_level == -1 %}
+                                            -
+                                        {% else %}
+                                            {{ challenge.get_latest_initial_anxiety_level }}
+                                        {% endif %}
                                 <a href="{% url 'challenge' challenge.id %}"><h3>{{ challenge.challenge_name }}</h3></a>
                                 <button class="btn btn-primary pull-right col-xs-3" disabled> Do the challenge </button>
                             </li>
@@ -31,7 +35,11 @@
                     {% else %}
                         <ul class="col-xs-6 col-xs-offset-3">
                             <li class="row">
-                                Level: {{ challenge.get_latest_initial_anxiety_level_as_str }}
+                                Level:  {% if challenge.get_latest_initial_anxiety_level == -1 %}
+                                            -
+                                        {% else %}
+                                            {{ challenge.get_latest_initial_anxiety_level }}
+                                        {% endif %}
                                 <a href="{% url 'challenge' challenge.id %}"><h3>{{ challenge.challenge_name }}</h3></a>
                                 <a class="btn btn-primary pull-right col-xs-3" href="{% url 'challenge-score-form-new' challenge.id %}"> Do the challenge </a>
                             </li>

--- a/ocdaction/ocdaction/templates/challenge/challenge_list.html
+++ b/ocdaction/ocdaction/templates/challenge/challenge_list.html
@@ -23,6 +23,7 @@
                     {% if another_challenge_in_progress %}
                         <ul class="col-xs-6 col-xs-offset-3">
                             <li class="row">
+                                Level: {{ challenge.get_latest_initial_anxiety_level }}
                                 <a href="{% url 'challenge' challenge.id %}"><h3>{{ challenge.challenge_name }}</h3></a>
                                 <button class="btn btn-primary pull-right col-xs-3" disabled> Do the challenge </button>
                             </li>
@@ -30,6 +31,7 @@
                     {% else %}
                         <ul class="col-xs-6 col-xs-offset-3">
                             <li class="row">
+                                Level: {{ challenge.get_latest_initial_anxiety_level }}
                                 <a href="{% url 'challenge' challenge.id %}"><h3>{{ challenge.challenge_name }}</h3></a>
                                 <a class="btn btn-primary pull-right col-xs-3" href="{% url 'challenge-score-form-new' challenge.id %}"> Do the challenge </a>
                             </li>


### PR DESCRIPTION
### ISSUE/TICKET NUMBER
Add challenges anxiety levels to Challenge Hierarchy page

### Describe the changes
Anxiety level for the latest exposure added next to each challenge, with "-" if there are no exposures yet.  Challenges are sorted by the highest anxiety level with the most recent displayed first if there is more than one challenge with the same anxiety level.  See screenshots.

### Screenshots (if appropriate)
<img width="589" alt="screen shot 2017-11-15 at 22 05 04" src="https://user-images.githubusercontent.com/23309660/32862914-92cc837c-ca51-11e7-9143-a89cf9ab6335.png">
<img width="593" alt="screen shot 2017-11-15 at 22 06 01" src="https://user-images.githubusercontent.com/23309660/32862920-970d62ee-ca51-11e7-8739-61bfd0cf7cc9.png">


### Questions or comments (if any)
Code is repetitive in models file but a simple way to return the "-", as `sorted` sorts on either integer or string, not both. 