### PR TITLE
Last 3 score cards displayed in challenge view page

### DIFF
--- a/ocdaction/challenges/templatetags/challenges_tags.py
+++ b/ocdaction/challenges/templatetags/challenges_tags.py
@@ -1,0 +1,12 @@
+from django import template
+from ..models import Challenge, AnxietyScoreCard
+
+register = template.Library()
+
+@register.simple_tag
+def render_anxiety_level(score):
+    if score:
+        anxiety_level = score
+    else:
+        anxiety_level = "-"
+    return anxiety_level

--- a/ocdaction/challenges/views.py
+++ b/ocdaction/challenges/views.py
@@ -74,7 +74,9 @@ def challenge_view(request, challenge_id):
     View a challenge
     """
     challenge = get_object_or_404(Challenge, pk=challenge_id)
-    context = {'challenge': challenge}
+    anxiety_score_cards = AnxietyScoreCard.objects.filter(challenge=challenge).order_by('-id')[:3]
+
+    context = {'challenge': challenge, 'anxiety_score_cards': anxiety_score_cards}
 
     return render(request, 'challenge/challenge_view.html', context)
 

--- a/ocdaction/ocdaction/templates/challenge/challenge_view.html
+++ b/ocdaction/ocdaction/templates/challenge/challenge_view.html
@@ -27,7 +27,7 @@
     <section>
         <ul class="col-xs-6 col-xs-offset-3">
             <h4>Your exposures for this challenge</h4>
-            <table class="table">
+            <table class="table table-responsive">
                 <thead>
                     <tr>
                         <th></th>
@@ -38,43 +38,43 @@
                 </thead>
                 <tbody>
                     <tr>
-                        <td>Anxiety at 0 min: </td>
+                        <td>Anxiety at 0 min:</td>
                         {% for card in anxiety_score_cards %}
                             <td>{% if card.anxiety_at_0_min %} {{ card.anxiety_at_0_min }} {% else %} - {% endif %}</td>
                         {% endfor %}
                     </tr>
                     <tr>
-                        <td>Anxiety at 5 min: </td>
+                        <td>Anxiety at 5 min:</td>
                         {% for card in anxiety_score_cards %}
                             <td>{% if card.anxiety_at_5_min %} {{ card.anxiety_at_5_min }} {% else %} - {% endif %}</td>
                         {% endfor %}
                     </tr>
                     <tr>
-                        <td>Anxiety at 10 min: </td>
+                        <td>Anxiety at 10 min:</td>
                         {% for card in anxiety_score_cards %}
                             <td>{% if card.anxiety_at_10_min %} {{ card.anxiety_at_10_min }} {% else %} - {% endif %}</td>
                         {% endfor %}
                     </tr>
                     <tr>
-                        <td>Anxiety at 15 min: </td>
+                        <td>Anxiety at 15 min:</td>
                         {% for card in anxiety_score_cards %}
                             <td>{% if card.anxiety_at_15_min %} {{ card.anxiety_at_15_min }} {% else %} - {% endif %}</td>
                         {% endfor %}
                     </tr>
                     <tr>
-                        <td>Anxiety at 30 min: </td>
+                        <td>Anxiety at 30 min:</td>
                         {% for card in anxiety_score_cards %}
                             <td>{% if card.anxiety_at_30_min %} {{ card.anxiety_at_30_min }} {% else %} - {% endif %}</td>
                         {% endfor %}
                     </tr>
                     <tr>
-                        <td>Anxiety at 60 min: </td>
+                        <td>Anxiety at 60 min:</td>
                         {% for card in anxiety_score_cards %}
                             <td>{% if card.anxiety_at_60_min %} {{ card.anxiety_at_60_min }} {% else %} - {% endif %}</td>
                         {% endfor %}
                     </tr>
                     <tr>
-                        <td>Anxiety at 120 min: </td>
+                        <td>Anxiety at 120 min:</td>
                         {% for card in anxiety_score_cards %}
                             <td>{% if card.anxiety_at_120_min %} {{ card.anxiety_at_120_min }} {% else %} - {% endif %}</td>
                         {% endfor %}

--- a/ocdaction/ocdaction/templates/challenge/challenge_view.html
+++ b/ocdaction/ocdaction/templates/challenge/challenge_view.html
@@ -25,6 +25,7 @@
             </ul>
     </section>
 
+    {% if anxiety_score_cards %}
     <section>
         <ul class="col-xs-6 col-xs-offset-3">
             <h4>Your exposures for this challenge</h4>
@@ -84,6 +85,7 @@
             </table>
         </ul>
     </section>
+    {% endif %}
 
     <script language="javascript">
         function checkArchive() {

--- a/ocdaction/ocdaction/templates/challenge/challenge_view.html
+++ b/ocdaction/ocdaction/templates/challenge/challenge_view.html
@@ -24,6 +24,66 @@
             </ul>
     </section>
 
+    <section>
+        <ul class="col-xs-6 col-xs-offset-3">
+            <h4>Your exposures for this challenge</h4>
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th></th>
+                        <th>Most recent</th>
+                        <th></th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Anxiety at 0 min: </td>
+                        {% for card in anxiety_score_cards %}
+                            <td>{% if card.anxiety_at_0_min %} {{ card.anxiety_at_0_min }} {% else %} - {% endif %}</td>
+                        {% endfor %}
+                    </tr>
+                    <tr>
+                        <td>Anxiety at 5 min: </td>
+                        {% for card in anxiety_score_cards %}
+                            <td>{% if card.anxiety_at_5_min %} {{ card.anxiety_at_5_min }} {% else %} - {% endif %}</td>
+                        {% endfor %}
+                    </tr>
+                    <tr>
+                        <td>Anxiety at 10 min: </td>
+                        {% for card in anxiety_score_cards %}
+                            <td>{% if card.anxiety_at_10_min %} {{ card.anxiety_at_10_min }} {% else %} - {% endif %}</td>
+                        {% endfor %}
+                    </tr>
+                    <tr>
+                        <td>Anxiety at 15 min: </td>
+                        {% for card in anxiety_score_cards %}
+                            <td>{% if card.anxiety_at_15_min %} {{ card.anxiety_at_15_min }} {% else %} - {% endif %}</td>
+                        {% endfor %}
+                    </tr>
+                    <tr>
+                        <td>Anxiety at 30 min: </td>
+                        {% for card in anxiety_score_cards %}
+                            <td>{% if card.anxiety_at_30_min %} {{ card.anxiety_at_30_min }} {% else %} - {% endif %}</td>
+                        {% endfor %}
+                    </tr>
+                    <tr>
+                        <td>Anxiety at 60 min: </td>
+                        {% for card in anxiety_score_cards %}
+                            <td>{% if card.anxiety_at_60_min %} {{ card.anxiety_at_60_min }} {% else %} - {% endif %}</td>
+                        {% endfor %}
+                    </tr>
+                    <tr>
+                        <td>Anxiety at 120 min: </td>
+                        {% for card in anxiety_score_cards %}
+                            <td>{% if card.anxiety_at_120_min %} {{ card.anxiety_at_120_min }} {% else %} - {% endif %}</td>
+                        {% endfor %}
+                    </tr>
+                </tbody>
+            </table>
+        </ul>
+    </section>
+
     <script language="javascript">
         function checkArchive() {
             if (confirm("Are you sure you want to archive this challenge? Once archived you will not be able to reactivate it.")) {

--- a/ocdaction/ocdaction/templates/challenge/challenge_view.html
+++ b/ocdaction/ocdaction/templates/challenge/challenge_view.html
@@ -1,6 +1,7 @@
 {% extends "layout.html" %}
 
 {% load static %}
+{% load challenges_tags %}
 
 {% block main %}
     <section class="container">
@@ -40,43 +41,43 @@
                     <tr>
                         <td>Anxiety at 0 min:</td>
                         {% for card in anxiety_score_cards %}
-                            <td>{% if card.anxiety_at_0_min %} {{ card.anxiety_at_0_min }} {% else %} - {% endif %}</td>
+                            <td>{% render_anxiety_level card.anxiety_at_0_min %}</td>
                         {% endfor %}
                     </tr>
                     <tr>
                         <td>Anxiety at 5 min:</td>
                         {% for card in anxiety_score_cards %}
-                            <td>{% if card.anxiety_at_5_min %} {{ card.anxiety_at_5_min }} {% else %} - {% endif %}</td>
+                            <td>{% render_anxiety_level card.anxiety_at_5_min %}</td>
                         {% endfor %}
                     </tr>
                     <tr>
                         <td>Anxiety at 10 min:</td>
                         {% for card in anxiety_score_cards %}
-                            <td>{% if card.anxiety_at_10_min %} {{ card.anxiety_at_10_min }} {% else %} - {% endif %}</td>
+                            <td>{% render_anxiety_level card.anxiety_at_10_min %}</td>
                         {% endfor %}
                     </tr>
                     <tr>
                         <td>Anxiety at 15 min:</td>
                         {% for card in anxiety_score_cards %}
-                            <td>{% if card.anxiety_at_15_min %} {{ card.anxiety_at_15_min }} {% else %} - {% endif %}</td>
+                            <td>{% render_anxiety_level card.anxiety_at_15_min %}</td>
                         {% endfor %}
                     </tr>
                     <tr>
                         <td>Anxiety at 30 min:</td>
                         {% for card in anxiety_score_cards %}
-                            <td>{% if card.anxiety_at_30_min %} {{ card.anxiety_at_30_min }} {% else %} - {% endif %}</td>
+                            <td>{% render_anxiety_level card.anxiety_at_30_min %}</td>
                         {% endfor %}
                     </tr>
                     <tr>
                         <td>Anxiety at 60 min:</td>
                         {% for card in anxiety_score_cards %}
-                            <td>{% if card.anxiety_at_60_min %} {{ card.anxiety_at_60_min }} {% else %} - {% endif %}</td>
+                            <td>{% render_anxiety_level card.anxiety_at_60_min %}</td>
                         {% endfor %}
                     </tr>
                     <tr>
                         <td>Anxiety at 120 min:</td>
                         {% for card in anxiety_score_cards %}
-                            <td>{% if card.anxiety_at_120_min %} {{ card.anxiety_at_120_min }} {% else %} - {% endif %}</td>
+                            <td>{% render_anxiety_level card.anxiety_at_120_min %}</td>
                         {% endfor %}
                     </tr>
                 </tbody>


### PR DESCRIPTION
### ISSUE/TICKET NUMBER
Add Anxiety levels results to a Challenge view page

### Describe the changes
Last 3 challenge score cards displayed on the challenge view page.  If there are no score cards, this section is hidden.

### Screenshots (if appropriate)
<img width="782" alt="screen shot 2017-11-19 at 17 03 15" src="https://user-images.githubusercontent.com/23309660/32993108-8f025a30-cd4b-11e7-85c0-3c607401a28f.png">

### Questions or comments (if any)
Implemented as a table in the template - no new design element to the PR