### PR TITLE
Small fix to check for user when marking challenge as in progress

### DIFF
--- a/ocdaction/challenges/models.py
+++ b/ocdaction/challenges/models.py
@@ -24,7 +24,7 @@ class Challenge(models.Model):
     @transaction.atomic
     def save(self, *args, **kwargs):
         if self.in_progress:
-            Challenge.objects.filter(in_progress=True).update(in_progress=False)
+            Challenge.objects.filter(user=request.user, in_progress=True).update(in_progress=False)
         super(Challenge, self).save(*args, **kwargs)
 
     def get_absolute_url(self):

--- a/ocdaction/challenges/views.py
+++ b/ocdaction/challenges/views.py
@@ -19,7 +19,7 @@ def challenge_list(request):
     sorted_challenges_by_anxiety = sorted(challenges.all(), reverse=True, key = lambda c: int(c.get_latest_initial_anxiety_level()))
     sorted_challenges = sorted(sorted_challenges_by_anxiety, reverse=True, key = lambda c: c.in_progress)
 
-    challenge_in_progress = Challenge.objects.filter(in_progress=True)
+    challenge_in_progress = Challenge.objects.filter(user=request.user, in_progress=True)
     anxiety_score_card = AnxietyScoreCard.objects.filter(challenge=challenge_in_progress).last()
 
     context = {


### PR DESCRIPTION
### ISSUE/TICKET NUMBER
n/a

### Describe the changes
This is a small fix to check that the challenge in progress is associated with the correct user (this ensures that if a challenge is in progress by another user it does not prevent another user starting a challenge).  I'm writing some tests and noticed this so wanted to push the fix asap.

### Screenshots (if appropriate)
Add "n/a" if nothing to attach
 - Before
 - After

### Questions or comments (if any)
Add "n/a" if nothing to say