### PR TITLE
Upgrating tar package to resolve security warning

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -306,6 +306,11 @@
         "supports-color": "0.2.0"
       }
     },
+    "chownr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
+    },
     "cliui": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
@@ -685,6 +690,14 @@
             "mime-db": "1.12.0"
           }
         }
+      }
+    },
+    "fs-minipass": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.3.tgz",
+      "integrity": "sha512-u1pHCXDx+CElfM6CuIeHDTKvb1Ya9ZhsMk7xTHTh6zHSRLK6O0DTVBN+E3wg8fruxAFp4oE07owrrzQfDA0b5Q==",
+      "requires": {
+        "minipass": "2.2.1"
       }
     },
     "fs.realpath": {
@@ -2032,11 +2045,26 @@
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
+    "minipass": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.1.tgz",
+      "integrity": "sha512-u1aUllxPJUI07cOqzR7reGmQxmCqlH88uIIsf6XZFEWgw7gXKpJdR+5R9Y3KEDmWYkdIz9wXZs3C0jOPxejk/Q==",
+      "requires": {
+        "yallist": "3.0.2"
+      }
+    },
+    "minizlib": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.0.4.tgz",
+      "integrity": "sha512-sN4U9tIJtBRwKbwgFh9qJfrPIQ/GGTRr1MGqkgOeMTLy8/lM0FcWU//FqlnZ3Vb7gJ+Mxh3FOg1EklibdajbaQ==",
+      "requires": {
+        "minipass": "2.2.1"
+      }
+    },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -2044,8 +2072,7 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },
@@ -2354,6 +2381,17 @@
             "stringstream": "0.0.5",
             "tough-cookie": "2.3.3",
             "tunnel-agent": "0.4.3"
+          }
+        },
+        "tar": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
+          "integrity": "sha1-FbzaskT6St1E5CRKAXbtuKqaK0Q=",
+          "dev": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
           }
         }
       }
@@ -2999,22 +3037,16 @@
       "dev": true
     },
     "tar": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
-      "integrity": "sha1-FbzaskT6St1E5CRKAXbtuKqaK0Q=",
-      "dev": true,
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.1.1.tgz",
+      "integrity": "sha512-p2lLtRABOEhuC28GDpMYwxcDYRqAFfiz2AIZiQlI+fhrACPKtQ1mcF/bPY8T1h9aKlpDpd+WE33Y2PJ/hWhm8g==",
       "requires": {
-        "block-stream": "0.0.9",
-        "fstream": "1.0.11",
-        "inherits": "2.0.3"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
-        }
+        "chownr": "1.0.1",
+        "fs-minipass": "1.2.3",
+        "minipass": "2.2.1",
+        "minizlib": "1.0.4",
+        "mkdirp": "0.5.1",
+        "yallist": "3.0.2"
       }
     },
     "tiny-lr": {
@@ -3203,6 +3235,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "yallist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
+      "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
     },
     "yargs": {
       "version": "3.10.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "scss-lint": "0.0.0"
   },
   "dependencies": {
-    "grunt-sync": "^0.5.2"
+    "grunt-sync": "^0.5.2",
+    "tar": "^4.1.1"
   }
 }


### PR DESCRIPTION
### ISSUE/TICKET NUMBER
[n/a]()

### Describe the changes
Upgraded tar to latest version to resolve  Github Warning `The tar dependency defined in package-lock.json has a known moderate severity security vulnerability in version range < 2.0.0 and should be updated.`
