### PR TITLE
Anxiety score tracking

### DIFF
--- a/ocdaction/challenges/forms.py
+++ b/ocdaction/challenges/forms.py
@@ -20,12 +20,20 @@ class ChallengeForm(forms.ModelForm):
         self.fields['compulsion'].label = 'Your Compulsion'
         self.fields['exposure'].label = 'Your Exposure'
 
-
 class AnxietyScoreCardForm(forms.ModelForm):
 
     class Meta:
         model = AnxietyScoreCard
         exclude = ['challenge']
+        widgets = {
+            'anxiety_at_0_min': forms.RadioSelect(attrs={'id': 'value'}),
+            'anxiety_at_5_min': forms.RadioSelect(attrs={'id': 'value'}),
+            'anxiety_at_10_min': forms.RadioSelect(attrs={'id': 'value'}),
+            'anxiety_at_15_min': forms.RadioSelect(attrs={'id': 'value'}),
+            'anxiety_at_30_min': forms.RadioSelect(attrs={'id': 'value'}),
+            'anxiety_at_60_min': forms.RadioSelect(attrs={'id': 'value'}),
+            'anxiety_at_120_min': forms.RadioSelect(attrs={'id': 'value'})
+        }
 
     def __init__(self, *args, **kwargs):
         super(AnxietyScoreCardForm, self).__init__(*args, **kwargs)

--- a/ocdaction/challenges/forms.py
+++ b/ocdaction/challenges/forms.py
@@ -26,13 +26,13 @@ class AnxietyScoreCardForm(forms.ModelForm):
         model = AnxietyScoreCard
         exclude = ['challenge']
         widgets = {
-            'anxiety_at_0_min': forms.RadioSelect(attrs={'id': 'value'}),
-            'anxiety_at_5_min': forms.RadioSelect(attrs={'id': 'value'}),
-            'anxiety_at_10_min': forms.RadioSelect(attrs={'id': 'value'}),
-            'anxiety_at_15_min': forms.RadioSelect(attrs={'id': 'value'}),
-            'anxiety_at_30_min': forms.RadioSelect(attrs={'id': 'value'}),
-            'anxiety_at_60_min': forms.RadioSelect(attrs={'id': 'value'}),
-            'anxiety_at_120_min': forms.RadioSelect(attrs={'id': 'value'})
+            'anxiety_at_0_min': forms.RadioSelect(),
+            'anxiety_at_5_min': forms.RadioSelect(),
+            'anxiety_at_10_min': forms.RadioSelect(),
+            'anxiety_at_15_min': forms.RadioSelect(),
+            'anxiety_at_30_min': forms.RadioSelect(),
+            'anxiety_at_60_min': forms.RadioSelect(),
+            'anxiety_at_120_min': forms.RadioSelect()
         }
 
     def __init__(self, *args, **kwargs):

--- a/ocdaction/challenges/forms.py
+++ b/ocdaction/challenges/forms.py
@@ -26,13 +26,13 @@ class AnxietyScoreCardForm(forms.ModelForm):
         model = AnxietyScoreCard
         exclude = ['challenge']
         widgets = {
-            'anxiety_at_0_min': forms.RadioSelect(),
-            'anxiety_at_5_min': forms.RadioSelect(),
-            'anxiety_at_10_min': forms.RadioSelect(),
-            'anxiety_at_15_min': forms.RadioSelect(),
-            'anxiety_at_30_min': forms.RadioSelect(),
-            'anxiety_at_60_min': forms.RadioSelect(),
-            'anxiety_at_120_min': forms.RadioSelect()
+            'anxiety_at_0_min': forms.RadioSelect(attrs={'id': 'label'}),
+            'anxiety_at_5_min': forms.RadioSelect(attrs={'id': 'label'}),
+            'anxiety_at_10_min': forms.RadioSelect(attrs={'id': 'label'}),
+            'anxiety_at_15_min': forms.RadioSelect(attrs={'id': 'label'}),
+            'anxiety_at_30_min': forms.RadioSelect(attrs={'id': 'label'}),
+            'anxiety_at_60_min': forms.RadioSelect(attrs={'id': 'label'}),
+            'anxiety_at_120_min': forms.RadioSelect(attrs={'id': 'label'})
         }
 
     def __init__(self, *args, **kwargs):

--- a/ocdaction/challenges/models.py
+++ b/ocdaction/challenges/models.py
@@ -76,7 +76,8 @@ class AnxietyScoreCard(models.Model):
     anxiety_at_0_min = models.CharField(
         max_length=2,
         choices=ANXIETY_SCORE_CHOICES,
-        blank=False
+        blank=False,
+        default=None
     )
     anxiety_at_5_min = models.CharField(
         max_length=2,

--- a/ocdaction/challenges/models.py
+++ b/ocdaction/challenges/models.py
@@ -61,16 +61,16 @@ class AnxietyScoreCard(models.Model):
     SCORE_TEN = '10'
 
     ANXIETY_SCORE_CHOICES = (
-        (SCORE_ONE, 'one'),
-        (SCORE_TWO, 'two'),
-        (SCORE_THREE, 'three'),
-        (SCORE_FOUR, 'four'),
-        (SCORE_FIVE, 'five'),
-        (SCORE_SIX, 'six'),
-        (SCORE_SEVEN, 'seven'),
-        (SCORE_EIGHT, 'eight'),
-        (SCORE_NINE, 'nine'),
-        (SCORE_TEN, 'ten'),
+        (SCORE_ONE, '1'),
+        (SCORE_TWO, '2'),
+        (SCORE_THREE, '3'),
+        (SCORE_FOUR, '4'),
+        (SCORE_FIVE, '5'),
+        (SCORE_SIX, '6'),
+        (SCORE_SEVEN, '7'),
+        (SCORE_EIGHT, '8'),
+        (SCORE_NINE, '9'),
+        (SCORE_TEN, '10'),
     )
 
     anxiety_at_0_min = models.CharField(

--- a/ocdaction/challenges/models.py
+++ b/ocdaction/challenges/models.py
@@ -49,7 +49,6 @@ class AnxietyScoreCard(models.Model):
     """
     Anxiety score card is a collection of scores for the challenge
     """
-    SCORE_ZERO = '0'
     SCORE_ONE = '1'
     SCORE_TWO = '2'
     SCORE_THREE = '3'
@@ -62,7 +61,6 @@ class AnxietyScoreCard(models.Model):
     SCORE_TEN = '10'
 
     ANXIETY_SCORE_CHOICES = (
-        (SCORE_ZERO, 'zero'),
         (SCORE_ONE, 'one'),
         (SCORE_TWO, 'two'),
         (SCORE_THREE, 'three'),

--- a/ocdaction/ocdaction/templates/base.html
+++ b/ocdaction/ocdaction/templates/base.html
@@ -16,7 +16,6 @@
         <!-- Latest compiled and minified CSS -->   
         <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet">
         <link href="{% static "styles/styles.css" %}" rel="stylesheet">
-        <link rel="shortcut icon" href="{% static "img/favicon.png" %}" type="image/x-icon">
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
 
     </head>

--- a/ocdaction/ocdaction/templates/challenge/challenge_score_form.html
+++ b/ocdaction/ocdaction/templates/challenge/challenge_score_form.html
@@ -24,7 +24,7 @@
                          <div class="fieldWrapper">
                              {{ field.errors }}
                              {{ field.label_tag }}
-                             {% for radio in field %}
+                             {% for radio in field|slice:"1:" %}
                                  {{ radio.choice_label }}
                                  {{ radio.tag }}
                              {% endfor %}
@@ -47,7 +47,7 @@
                              <fieldset disabled="disabled">
                              {{ field.errors }}
                              {{ field.label_tag }}
-                             {% for radio in field %}
+                             {% for radio in field|slice:"1:" %}
                                  {{ radio.choice_label }}
                                  {{ radio.tag }}
                              {% endfor %}

--- a/ocdaction/ocdaction/templates/challenge/challenge_score_form.html
+++ b/ocdaction/ocdaction/templates/challenge/challenge_score_form.html
@@ -23,7 +23,11 @@
                      {% else %}
                          <div class="fieldWrapper">
                              {{ field.errors }}
-                             {{ field.label_tag }} {{ field }}
+                             {{ field.label_tag }}
+                             {% for radio in field %}
+                                 {{ radio.choice_label }}
+                                 {{ radio.tag }}
+                             {% endfor %}
                              <button class="btn btn-primary pull-left col-xs-4 col-xs-offset-8" type="submit">Save</button>
                          </div>
                      {% endif %}
@@ -31,14 +35,22 @@
                      {% if field.name == 'anxiety_at_0_min' %}
                          <div class="fieldWrapper">
                              {{ field.errors }}
-                             {{ field.label_tag }} {{ field }}
+                             {{ field.label_tag }}
+                             {% for radio in field %}
+                                 {{ radio.choice_label }}
+                                 {{ radio.tag }}
+                             {% endfor %}
                              <button class="btn btn-primary pull-left col-xs-4 col-xs-offset-8" type="submit">Save</button>
                          </div>
                      {% else %}
                          <div class="fieldWrapper">
                              <fieldset disabled="disabled">
                              {{ field.errors }}
-                             {{ field.label_tag }} {{ field }}
+                             {{ field.label_tag }}
+                             {% for radio in field %}
+                                 {{ radio.choice_label }}
+                                 {{ radio.tag }}
+                             {% endfor %}
                              </fieldset>
                              <button class="btn btn-primary pull-left col-xs-4 col-xs-offset-8" type="submit" disabled>Save</button>
                          </div>


### PR DESCRIPTION
### ISSUE/TICKET NUMBER
Anxiety level tracking page - backend for the new design

### Describe the changes
The dropdown for anxiety levels has been replaced with radio buttons so that the styling for the new design can be implemented. The "------" that shows in these fields if no selection has been made has been removed (for anxiety_score_at_0_min) and hidden for the rest of the fields - this was to avoid making fields required in the model when they are not required to be completed.
This PR also removes the reference to favicon.png which was causing a 404 error in runserver.

### Screenshots (if appropriate)
Add "n/a" if nothing to attach
 - Before
 - After
<img width="753" alt="screen shot 2018-01-19 at 21 43 05" src="https://user-images.githubusercontent.com/23309660/35173014-ca515924-fd61-11e7-8642-e496babc4a06.png">


### Questions or comments (if any)
Add "n/a" if nothing to say