### PR TITLE
Upgrade django

### DIFF
--- a/ocdaction/challenges/models.py
+++ b/ocdaction/challenges/models.py
@@ -1,5 +1,5 @@
 from __future__ import unicode_literals
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from django.db import models, transaction
 

--- a/ocdaction/challenges/views.py
+++ b/ocdaction/challenges/views.py
@@ -80,7 +80,7 @@ def challenge_view(request, challenge_id):
     """
     View a challenge
     """
-    challenge = get_object_or_404(Challenge, pk=challenge_id)
+    challenge = get_object_or_404(Challenge.objects.filter(user=request.user), pk=challenge_id)
     anxiety_score_cards = AnxietyScoreCard.objects.filter(challenge=challenge).order_by('-id')[:3]
 
     context = {'challenge': challenge, 'anxiety_score_cards': anxiety_score_cards}
@@ -93,7 +93,7 @@ def challenge_edit(request, challenge_id):
     """
     Edit a challenge
     """
-    challenge_inst = get_object_or_404(Challenge, pk=challenge_id)
+    challenge_inst = get_object_or_404(Challenge.objects.filter(user=request.user), pk=challenge_id)
 
     if request.method == 'POST':
         challenge_form = ChallengeForm(request.POST, instance=challenge_inst)
@@ -123,7 +123,7 @@ def challenge_archive(request, challenge_id):
     """
     Archive a challenge
     """
-    challenge = get_object_or_404(Challenge, pk=challenge_id)
+    challenge = get_object_or_404(Challenge.objects.filter(user=request.user), pk=challenge_id)
     challenge.archive()
 
     return redirect('challenge-list')
@@ -134,7 +134,7 @@ def challenge_summary(request, challenge_id, score_id):
     """
     Mark challenge complete and display summary of a challenge
     """
-    challenge = get_object_or_404(Challenge, pk=challenge_id)
+    challenge = get_object_or_404(Challenge.objects.filter(user=request.user), pk=challenge_id)
     anxiety_score_card = get_object_or_404(AnxietyScoreCard, pk=score_id)
 
     challenge.in_progress = False
@@ -156,7 +156,7 @@ def challenge_score_form_new(request, challenge_id):
     Start doing a challenge, creating a new score card
     """
 
-    challenge = get_object_or_404(Challenge, pk=challenge_id)
+    challenge = get_object_or_404(Challenge.objects.filter(user=request.user), pk=challenge_id)
 
     if request.method == "POST":
         anxiety_score_form = AnxietyScoreCardForm(request.POST)
@@ -192,7 +192,7 @@ def challenge_score_form(request, challenge_id, score_id):
     Continue doing a challenge, on an existing score card
     """
 
-    challenge = get_object_or_404(Challenge, pk=challenge_id)
+    challenge = get_object_or_404(Challenge.objects.filter(user=request.user), pk=challenge_id)
     anxiety_score_card = get_object_or_404(AnxietyScoreCard, pk=score_id)
 
     if request.method == "POST":

--- a/ocdaction/core/views.py
+++ b/ocdaction/core/views.py
@@ -7,7 +7,7 @@ def home_index(request):
     """
 
     template_name = "index.html"
-    if request.user.is_authenticated():
+    if request.user.is_authenticated:
         return redirect('challenge-list')
     else:
         return render(request, template_name)

--- a/ocdaction/ocdaction/settings/__init__.py
+++ b/ocdaction/ocdaction/settings/__init__.py
@@ -159,7 +159,7 @@ CONTEXT_PROCESSORS = [
     "django.template.context_processors.static",
     "django.template.context_processors.tz",
     "django.contrib.messages.context_processors.messages",
-    "django.core.context_processors.request",
+    "django.template.context_processors.request",
 ]
 
 # Registration settings

--- a/ocdaction/ocdaction/settings/__init__.py
+++ b/ocdaction/ocdaction/settings/__init__.py
@@ -132,7 +132,7 @@ USE_TZ = True
 
 AUTH_USER_MODEL = 'profiles.OCDActionUser'
 
-#STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 MEDIA_URL = 'http://res.cloudinary.com/ocd-action-app/image/upload/'
 

--- a/ocdaction/ocdaction/settings/__init__.py
+++ b/ocdaction/ocdaction/settings/__init__.py
@@ -46,7 +46,6 @@ MIDDLEWARE_CLASSES = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 

--- a/ocdaction/ocdaction/settings/__init__.py
+++ b/ocdaction/ocdaction/settings/__init__.py
@@ -133,7 +133,7 @@ USE_TZ = True
 
 AUTH_USER_MODEL = 'profiles.OCDActionUser'
 
-STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+#STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 MEDIA_URL = 'http://res.cloudinary.com/ocd-action-app/image/upload/'
 

--- a/ocdaction/ocdaction/settings/__init__.py
+++ b/ocdaction/ocdaction/settings/__init__.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE_CLASSES = [
     'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -48,7 +49,6 @@ MIDDLEWARE_CLASSES = [
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'whitenoise.middleware.WhiteNoiseMiddleware',
 
 ]
 

--- a/ocdaction/ocdaction/settings/__init__.py
+++ b/ocdaction/ocdaction/settings/__init__.py
@@ -132,7 +132,7 @@ USE_TZ = True
 
 AUTH_USER_MODEL = 'profiles.OCDActionUser'
 
-STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+#STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 MEDIA_URL = 'http://res.cloudinary.com/ocd-action-app/image/upload/'
 

--- a/ocdaction/ocdaction/settings/__init__.py
+++ b/ocdaction/ocdaction/settings/__init__.py
@@ -133,7 +133,7 @@ USE_TZ = True
 
 AUTH_USER_MODEL = 'profiles.OCDActionUser'
 
-STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 MEDIA_URL = 'http://res.cloudinary.com/ocd-action-app/image/upload/'
 

--- a/ocdaction/ocdaction/settings/__init__.py
+++ b/ocdaction/ocdaction/settings/__init__.py
@@ -39,7 +39,7 @@ INSTALLED_APPS = [
 
 ]
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/ocdaction/ocdaction/templates/registration/register.html
+++ b/ocdaction/ocdaction/templates/registration/register.html
@@ -32,9 +32,10 @@
                             {% render_field field placeholder=field.label class="form-control" %}
                             {% endif %}
 
-
-                            {% if field.help_text %}
-                            <p class="helptext">{{ field.help_text|safe }}</p>
+                            {% if field.name != "password1" %}
+                                {% if field.help_text %}
+                                <p class="helptext">{{ field.help_text|safe }}</p>
+                                {% endif %}
                             {% endif %}
 
                         </div>

--- a/ocdaction/ocdaction/wsgi.py
+++ b/ocdaction/ocdaction/wsgi.py
@@ -7,7 +7,6 @@ For more information on this file, see
 https://docs.djangoproject.com/en/1.9/howto/deployment/wsgi/
 """
 
-import os
 from whitenoise.django import DjangoWhiteNoise
 
 from django.core.wsgi import get_wsgi_application

--- a/ocdaction/profiles/urls.py
+++ b/ocdaction/profiles/urls.py
@@ -25,14 +25,12 @@ urlpatterns = [
     ),
     url(
         r'^login/$',
-        auth_views.login,
-        {'template_name': 'profiles/login.html'},
+        auth_views.LoginView.as_view(template_name='profiles/login.html'),
         name='login',
     ),
     url(
         r'^logout/$',
-        auth_views.logout,
-        {'template_name': 'profiles/logout.html'},
+        auth_views.LogoutView.as_view(template_name='profiles/logout.html'),
         name='logout',
     ),
     url(

--- a/ocdaction/profiles/urls.py
+++ b/ocdaction/profiles/urls.py
@@ -35,20 +35,17 @@ urlpatterns = [
     ),
     url(
         r'^password-reset/$',
-        auth_views.password_reset,
-        {'template_name': 'registration/password_reset.html'},
+        auth_views.PasswordResetView.as_view(template_name='registration/password_reset.html'),
         name='password_reset',
     ),
     url(
         r'^password-reset/done/$',
-        auth_views.password_reset_done,
-        {'template_name': 'registration/password_reset_done.html'},
+        auth_views.PasswordResetDoneView.as_view(template_name='registration/password_reset_done.html'),
         name='password_reset_done',
     ),
     url(
         r'^password-reset/complete/$',
-        auth_views.password_reset_complete,
-        {'template_name': 'registration/password_reset_complete.html'},
+        auth_views.PasswordResetCompleteView.as_view(template_name='registration/password_reset_complete.html'),
         name='password_reset_complete',
     ),
     url(r'^accounts/', include('registration.backends.default.urls')),

--- a/ocdaction/tests/challenges/test_challenges.py
+++ b/ocdaction/tests/challenges/test_challenges.py
@@ -5,7 +5,7 @@ from challenges.models import Challenge, AnxietyScoreCard
 from django.test import TestCase, RequestFactory
 from challenges.views import *
 from challenges.forms import *
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 
 @pytest.mark.django_db

--- a/ocdaction/tests/challenges/test_challenges.py
+++ b/ocdaction/tests/challenges/test_challenges.py
@@ -138,55 +138,55 @@ class ViewsTest(TestCase):
         request = self.factory.get(reverse('challenge-list'))
         request.user = self.user
         response = challenge_list(request)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
     def test_challenge_list_archived(self):
         request = self.factory.get(reverse('challenge-list-archived'))
         request.user = self.user
         response = challenge_list_archived(request)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
     def test_challenge_add(self):
         request = self.factory.get(reverse('challenge-add'))
         request.user = self.user
         response = challenge_add(request)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
     def test_challenge_view(self):
         request = self.factory.get(reverse('challenge', args=(self.challenge.pk,)))
         request.user = self.user
         response = challenge_view(request, self.challenge.pk)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
     def test_challenge_edit(self):
         request = self.factory.get(reverse('challenge-edit', args=(self.challenge.pk,)))
         request.user = self.user
         response = challenge_edit(request, self.challenge.pk)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
     def test_challenge_archive(self):
         request = self.factory.get(reverse('challenge-archive', args=(self.challenge.pk,)))
         request.user = self.user
         response = challenge_archive(request, self.challenge.pk)
-        self.assertEqual(response.status_code, 302)
+        assert response.status_code == 302
 
     def test_challenge_summary(self):
         request = self.factory.get(reverse('challenge-summary', args=(self.challenge.pk, self.score_card.pk,)))
         request.user = self.user
         response = challenge_summary(request, self.challenge.pk, self.score_card.pk)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
     def test_challenge_score_form_new(self):
         request = self.factory.get(reverse('challenge-score-form-new', args=(self.challenge.pk,)))
         request.user = self.user
         response = challenge_score_form_new(request, self.challenge.pk)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
     def test_challenge_score_form(self):
         request = self.factory.get(reverse('challenge-score-form', args=(self.challenge.pk, self.score_card.pk,)))
         request.user = self.user
         response = challenge_score_form(request, self.challenge.pk, self.score_card.pk)
-        self.assertEqual(response.status_code, 200)
+        assert response.status_code == 200
 
 @pytest.mark.parametrize(
     'challenge_name, obsession, compulsion, exposure, validity',

--- a/ocdaction/tests/challenges/test_challenges.py
+++ b/ocdaction/tests/challenges/test_challenges.py
@@ -4,6 +4,7 @@ from tests.factories import UserFactory, ChallengeFactory
 from challenges.models import Challenge, AnxietyScoreCard
 from django.test import TestCase, RequestFactory
 from challenges.views import *
+from challenges.forms import *
 from django.core.urlresolvers import reverse
 
 
@@ -187,3 +188,46 @@ class ViewsTest(TestCase):
         response = challenge_score_form(request, self.challenge.pk, self.score_card.pk)
         self.assertEqual(response.status_code, 200)
 
+@pytest.mark.parametrize(
+    'challenge_name, obsession, compulsion, exposure, validity',
+    [('', '', '', '', False),
+     ('', 'o', 'c', 'e', False),
+     ('challenge', '', '', '', True),
+     ('challenge', 'o', 'c', 'e', True),
+     ])
+
+def test_challenge_form(challenge_name, obsession, compulsion, exposure, validity):
+    form = ChallengeForm(data={
+        'challenge_name': challenge_name,
+        'obsession': obsession,
+        'compulsion': compulsion,
+        'exposure': exposure,
+    })
+
+    assert form.is_valid() is validity
+
+@pytest.mark.parametrize(
+    'anxiety_at_0_min, anxiety_at_5_min, anxiety_at_10_min, anxiety_at_15_min, anxiety_at_30_min, anxiety_at_60_min, anxiety_at_120_min, validity',
+    [('', '', '', '', '', '', '', False),
+     ('', '1', '', '', '', '', '', False),
+     ('', '', '1', '', '', '', '', False),
+     ('', '', '', '1', '', '', '', False),
+     ('', '', '', '', '1', '', '', False),
+     ('', '', '', '', '', '1', '', False),
+     ('', '', '', '', '', '', '1', False),
+     ('1', '', '', '', '', '', '', True),
+     ('1', '', '', '', '', '', '1', True),
+     ])
+
+def test_anxietyscore_form(anxiety_at_0_min, anxiety_at_5_min, anxiety_at_10_min, anxiety_at_15_min, anxiety_at_30_min, anxiety_at_60_min, anxiety_at_120_min, validity):
+    form = AnxietyScoreCardForm(data={
+        'anxiety_at_0_min': anxiety_at_0_min,
+        'anxiety_at_5_min': anxiety_at_5_min,
+        'anxiety_at_10_min': anxiety_at_10_min,
+        'anxiety_at_15_min': anxiety_at_15_min,
+        'anxiety_at_30_min': anxiety_at_30_min,
+        'anxiety_at_60_min': anxiety_at_60_min,
+        'anxiety_at_120_min': anxiety_at_120_min,
+    })
+
+    assert form.is_valid() is validity

--- a/ocdaction/tests/challenges/test_challenges.py
+++ b/ocdaction/tests/challenges/test_challenges.py
@@ -74,6 +74,8 @@ def test_get_latest_initial_anxiety_level_no_score_card():
     # Check that if there is no anxiety score card for a challenge, -1 is returned
     assert challenge.get_latest_initial_anxiety_level() == -1
 
+
+# Tests for marking challenges in progress
 class ChallengesInProgressTest(TestCase):
 
     def setUp(self):
@@ -122,6 +124,7 @@ class ChallengesInProgressTest(TestCase):
         assert challenge1.in_progress is True
 
 
+# Test each of the views
 class ViewsTest(TestCase):
 
     def setUp(self):
@@ -188,6 +191,8 @@ class ViewsTest(TestCase):
         response = challenge_score_form(request, self.challenge.pk, self.score_card.pk)
         assert response.status_code == 200
 
+
+# Test the forms
 @pytest.mark.parametrize(
     'challenge_name, obsession, compulsion, exposure, validity',
     [('', '', '', '', False),

--- a/ocdaction/tests/challenges/test_challenges.py
+++ b/ocdaction/tests/challenges/test_challenges.py
@@ -130,7 +130,7 @@ class ViewsTest(TestCase):
     def setUp(self):
         self.factory = RequestFactory()
         self.user = UserFactory.create()
-        self.challenge = ChallengeFactory.create()
+        self.challenge = ChallengeFactory.create(user=self.user)
         self.score_card = AnxietyScoreCard.objects.create(
             challenge=self.challenge,
             anxiety_at_0_min='9',

--- a/ocdaction/tests/challenges/test_challenges.py
+++ b/ocdaction/tests/challenges/test_challenges.py
@@ -207,7 +207,8 @@ def test_challenge_form(challenge_name, obsession, compulsion, exposure, validit
     assert form.is_valid() is validity
 
 @pytest.mark.parametrize(
-    'anxiety_at_0_min, anxiety_at_5_min, anxiety_at_10_min, anxiety_at_15_min, anxiety_at_30_min, anxiety_at_60_min, anxiety_at_120_min, validity',
+    'anxiety_at_0_min, anxiety_at_5_min, anxiety_at_10_min, anxiety_at_15_min, anxiety_at_30_min, anxiety_at_60_min, '
+    'anxiety_at_120_min, validity',
     [('', '', '', '', '', '', '', False),
      ('', '1', '', '', '', '', '', False),
      ('', '', '1', '', '', '', '', False),
@@ -219,7 +220,8 @@ def test_challenge_form(challenge_name, obsession, compulsion, exposure, validit
      ('1', '', '', '', '', '', '1', True),
      ])
 
-def test_anxietyscore_form(anxiety_at_0_min, anxiety_at_5_min, anxiety_at_10_min, anxiety_at_15_min, anxiety_at_30_min, anxiety_at_60_min, anxiety_at_120_min, validity):
+def test_anxietyscore_form(anxiety_at_0_min, anxiety_at_5_min, anxiety_at_10_min, anxiety_at_15_min, anxiety_at_30_min,
+                           anxiety_at_60_min, anxiety_at_120_min, validity):
     form = AnxietyScoreCardForm(data={
         'anxiety_at_0_min': anxiety_at_0_min,
         'anxiety_at_5_min': anxiety_at_5_min,

--- a/ocdaction/tests/profiles/test_profiles.py
+++ b/ocdaction/tests/profiles/test_profiles.py
@@ -2,10 +2,6 @@ import pytest
 
 from tests.factories import UserFactory
 from profiles.models import OCDActionUser
-from django.test import TestCase, RequestFactory
-from profiles.views import *
-from profiles.forms import *
-from django.core.urlresolvers import reverse
 
 @pytest.mark.django_db
 def test_create_user():
@@ -18,3 +14,4 @@ def test_create_user():
     UserFactory.create()
     number_users = OCDActionUser.objects.count()
     assert number_users == 1
+

--- a/ocdaction/tests/profiles/test_profiles.py
+++ b/ocdaction/tests/profiles/test_profiles.py
@@ -1,0 +1,20 @@
+import pytest
+
+from tests.factories import UserFactory
+from profiles.models import OCDActionUser
+from django.test import TestCase, RequestFactory
+from profiles.views import *
+from profiles.forms import *
+from django.core.urlresolvers import reverse
+
+@pytest.mark.django_db
+def test_create_user():
+
+    # Check there are 0 users before a new user is added
+    number_users = OCDActionUser.objects.count()
+    assert number_users == 0
+
+    # Check there is 1 user after a new user is added
+    UserFactory.create()
+    number_users = OCDActionUser.objects.count()
+    assert number_users == 1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ whitenoise==3.3.1
 wsgiref==0.1.2
 django-custom-user==0.6
 django-registration-redux==1.4
-dj-database-url==0.4.1
+dj-database-url==0.4.2
 django-widget-tweaks==1.4.1               # Tweaks form field rendering in templates, not in Python
 boto==2.46.1               				  # Sending emails using Amazon SES
 django-ses==0.8.2                         # Sending emails using Amazon SES 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,7 +7,7 @@ psycopg2==2.7.3.2
 whitenoise==3.3.1
 wsgiref==0.1.2
 django-custom-user==0.6
-django-registration-redux==1.4
+django-registration-redux==2.1
 dj-database-url==0.4.2
 django-widget-tweaks==1.4.1               # Tweaks form field rendering in templates, not in Python
 boto==2.48.0               				  # Sending emails using Amazon SES

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@
 Django==1.10.8
 gunicorn==19.5.0
 psycopg2==2.7.3.1
-whitenoise==3.1
+whitenoise==3.3.1
 wsgiref==0.1.2
 django-custom-user==0.6
 django-registration-redux==1.4

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,5 +10,5 @@ django-custom-user==0.6
 django-registration-redux==1.4
 dj-database-url==0.4.2
 django-widget-tweaks==1.4.1               # Tweaks form field rendering in templates, not in Python
-boto==2.46.1               				  # Sending emails using Amazon SES
+boto==2.48.0               				  # Sending emails using Amazon SES
 django-ses==0.8.2                         # Sending emails using Amazon SES 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 # Core requirements
 # that are needed for all enviroments
 
-Django==1.9.6
+Django==1.10.8
 gunicorn==19.5.0
 psycopg2==2.7.3.1
 whitenoise==3.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,7 @@
 
 Django==1.10.8
 gunicorn==19.7.1
-psycopg2==2.7.3.1
+psycopg2==2.7.3.2
 whitenoise==3.3.1
 wsgiref==0.1.2
 django-custom-user==0.6

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 # Core requirements
-# that are needed for all enviroments
+# that are needed for all environments
 
-Django==1.10.8
+Django==1.11.9
 gunicorn==19.7.1
 psycopg2==2.7.3.2
 whitenoise==3.3.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@
 # that are needed for all enviroments
 
 Django==1.10.8
-gunicorn==19.5.0
+gunicorn==19.7.1
 psycopg2==2.7.3.1
 whitenoise==3.3.1
 wsgiref==0.1.2

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -5,7 +5,7 @@
 
 factory_boy==2.9.2         # For fixture generation
 flake8==3.3.0			   # For linting the files
-pytest==3.0.5              # Our Python testing library
+pytest==3.3.2              # Our Python testing library
 pytest-django==3.1.2       # Integrates pytest with django
 pytest-factoryboy==1.3.0   # Factory_Boy integration with pytest fixtures
 pytest-sugar==0.8.0        # For better pytest output

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -3,7 +3,7 @@
 
 -r base.txt
 
-factory_boy==2.8.1         # For fixture generation
+factory_boy==2.9.2         # For fixture generation
 flake8==3.3.0			   # For linting the files
 pytest==3.0.5              # Our Python testing library
 pytest-django==3.1.2       # Integrates pytest with django


### PR DESCRIPTION
### ISSUE/TICKET NUMBER
#100 

### Describe the changes
Project updated to use Django 1.11 which is the latest LTS version and will be supported until at least April 2020.
External packages have also been updated where possible
More tests added
Also includes bug fix where it was possible for users to change the url and access other user's challenges - now returns 404 if attempting to access another user's data 

### Screenshots (if appropriate)
n/a

### Questions or comments (if any)
CircleCI tests will fail for this PR because of some of the changes introduced, however the updated test suite passes locally
Note that to test this locally you will need to create another virtualenv and install all the requirements.