### PR TITLE
Contact form redirection

### DIFF
--- a/ocdaction/ocdaction/templates/core/contact.html
+++ b/ocdaction/ocdaction/templates/core/contact.html
@@ -64,6 +64,7 @@
                     <div class="row text-center col-sm-10">
                         <div class="margin-top-15">
                             <button class="button button--primary" type="submit">Contact Us Now</button>
+                            <input type="hidden" name="_next" value="{% url 'contact' %}">
                         </div>
                     </div>
                 </form>

--- a/ocdaction/ocdaction/templates/layout.html
+++ b/ocdaction/ocdaction/templates/layout.html
@@ -73,7 +73,7 @@
 		        <li class="global-footer__item"><a class="global-footer__link" href="mailto:info@ocdaction.org.uk">Info</a></li>
 		    </ul>
 		  </div>
-	      <span class="global-footer__legal col-xs-12 small">Copyright &#xA9; <a href="http://ocdyouth.org/">OCD Youth</a> | Created by <a href="http://www.womenhackfornonprofits.com/" class="small">Women Hack For Non-Profits 2018</a></span>
+	      <span class="global-footer__legal col-xs-12 small">Copyright &#xA9; <a href="http://ocdyouth.org/" class="small">OCD Youth</a> | Created by <a href="http://www.womenhackfornonprofits.com/" class="small">Women Hack For Non-Profits 2018</a></span>
 	    </div>
     </footer>
 {% endblock %}


### PR DESCRIPTION
### ISSUE/TICKET NUMBER
https://trello.com/c/bOP0CKCv

### Describe the changes
After user submitting a form they were taken to formspree confirmation page, with no link back to the ocd page. For now we're skipping formspree confirmation page and straight after captcha check a user is taken back to a contact page. We might develop a custom thanks/confirmation page in the future if users will lack any form of confirmation the form has been sent. So that's juts a quick solution that was request by a client.

With this PR also:
- adjust copyright link to be the same size as WHFNP one in a footer
