### PR TITLE
Delete users challenge data

### DIFF
--- a/ocdaction/challenges/urls.py
+++ b/ocdaction/challenges/urls.py
@@ -3,17 +3,7 @@
 """
 from django.conf.urls import url
 
-from .views import (
-    challenge_list,
-    challenge_list_archived,
-    challenge_add,
-    challenge_view,
-    challenge_edit,
-    challenge_archive,
-    challenge_score_form_new,
-    challenge_score_form,
-    challenge_summary
-)
+from .views import *
 
 urlpatterns = [
     url(
@@ -60,5 +50,10 @@ urlpatterns = [
         r'^(?P<challenge_id>\d+)/summary/(?P<score_id>\d+)/$',
         challenge_summary,
         name="challenge-summary"
+    ),
+    url(
+        r'^erase-my-record/$',
+        challenge_erase_my_record,
+        name="challenge-erase-my-record"
     ),
 ]

--- a/ocdaction/challenges/urls.py
+++ b/ocdaction/challenges/urls.py
@@ -56,4 +56,9 @@ urlpatterns = [
         challenge_erase_my_record,
         name="challenge-erase-my-record"
     ),
+    url(
+        r'^delete-users-challenges/$',
+        delete_users_challenges,
+        name="delete-users-challenges"
+    ),
 ]

--- a/ocdaction/challenges/views.py
+++ b/ocdaction/challenges/views.py
@@ -220,6 +220,20 @@ def challenge_score_form(request, challenge_id, score_id):
 def challenge_erase_my_record(request):
     return render(request, 'challenge/challenge_erase_my_record.html')
 
+@login_required
+def delete_users_challenges(request):
+    """
+    Delete all challenges and associated score cards for a user
+    """
+    challenges = Challenge.objects.filter(user=request.user)
+
+    for challenge in challenges:
+        anxiety_score_cards = AnxietyScoreCard.objects.filter(challenge=challenge)
+        anxiety_score_cards.delete()
+        challenge.delete()
+
+    return render(request, 'profiles/my_account_confirm.html')
+
 
 
 

--- a/ocdaction/challenges/views.py
+++ b/ocdaction/challenges/views.py
@@ -215,3 +215,11 @@ def challenge_score_form(request, challenge_id, score_id):
         'challenge/challenge_score_form.html',
         context
     )
+
+@login_required
+def challenge_erase_my_record(request):
+    return render(request, 'challenge/challenge_erase_my_record.html')
+
+
+
+

--- a/ocdaction/ocdaction/settings/development.py
+++ b/ocdaction/ocdaction/settings/development.py
@@ -5,7 +5,7 @@ SECRET_KEY = 'FAKEforDEV'
 
 DEBUG = True
 
-#EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 LOGGING = {
     'version': 1,

--- a/ocdaction/ocdaction/templates/challenge/challenge_erase_my_record.html
+++ b/ocdaction/ocdaction/templates/challenge/challenge_erase_my_record.html
@@ -1,0 +1,24 @@
+{% extends "layout.html" %}
+
+{% load static %}
+{% block title %}My Account{% endblock %}
+
+{% block main %}
+<section class="container">
+    <h1 class="col-lg-12">My Account</h1>
+    <div class="col-xs-12 col-md-6 col-md-offset-3">
+        <div class="row">
+            <h5 class="text-left font-bold">Are you sure you want to erase all your challenges records on OCD Youth?</h5>
+            <p>Once erased you cannot recover the record.
+            </p>
+            <div class="margin-top-30">
+                <a class="btn btn-lg btn-outline btn-warning" href="#">Yes, erase my record</a>
+            </div>
+            <div class="margin-top-30">
+                <a href="{% url 'my-account' %}">Cancel and go back to last page</a>
+            </div>
+        </div>
+        
+    </div>
+</section>
+{% endblock %}

--- a/ocdaction/ocdaction/templates/challenge/challenge_erase_my_record.html
+++ b/ocdaction/ocdaction/templates/challenge/challenge_erase_my_record.html
@@ -12,7 +12,7 @@
             <p>Once erased you cannot recover the record.
             </p>
             <div class="margin-top-30">
-                <a class="btn btn-lg btn-outline btn-warning" href="#">Yes, erase my record</a>
+                <a class="btn btn-lg btn-outline btn-warning" href="{% url 'delete-users-challenges' %}">Yes, erase my record</a>
             </div>
             <div class="margin-top-30">
                 <a href="{% url 'my-account' %}">Cancel and go back to last page</a>

--- a/ocdaction/ocdaction/templates/profiles/my_account.html
+++ b/ocdaction/ocdaction/templates/profiles/my_account.html
@@ -13,7 +13,7 @@
                 You can log in with the same email and password.
             </p>
             <div class="margin-top-30">
-                <a class="btn btn-lg btn-outline btn-warning" href="#">Erase My Record</a>
+                <a class="btn btn-lg btn-outline btn-warning" href="{% url 'challenge-erase-my-record' %}">Erase My Record</a>
             </div>
         </div>
         

--- a/ocdaction/ocdaction/templates/profiles/my_account_confirm.html
+++ b/ocdaction/ocdaction/templates/profiles/my_account_confirm.html
@@ -9,7 +9,7 @@
     <div class="col-xs-12 col-md-6 col-md-offset-3">
         <div class="row">
             <h5 class="text-left font-bold">Your record is now deleted</h5>
-            <p>You can return to the <a href="{% url 'challenge-list' %}">challenges page</a> to addd new challenges.
+            <p>You can return to the <a href="{% url 'challenge-list' %}">challenges page</a> to add new challenges.
             </p>
         </div>
         

--- a/ocdaction/ocdaction/templates/profiles/my_account_confirm.html
+++ b/ocdaction/ocdaction/templates/profiles/my_account_confirm.html
@@ -1,0 +1,18 @@
+{% extends "layout.html" %}
+
+{% load static %}
+{% block title %}My Account{% endblock %}
+
+{% block main %}
+<section class="container">
+    <h1 class="col-lg-12">My Account</h1>
+    <div class="col-xs-12 col-md-6 col-md-offset-3">
+        <div class="row">
+            <h5 class="text-left font-bold">Your record is now deleted</h5>
+            <p>You can return to the <a href="{% url 'challenge-list' %}">challenges page</a> to addd new challenges.
+            </p>
+        </div>
+        
+    </div>
+</section>
+{% endblock %}

--- a/ocdaction/profiles/urls.py
+++ b/ocdaction/profiles/urls.py
@@ -51,7 +51,7 @@ urlpatterns = [
     url(r'^accounts/', include('registration.backends.default.urls')),
 
     url(
-    r'^my-account',
+        r'^my-account/$',
         my_account,
         name="my-account"
     ),

--- a/ocdaction/tests/challenges/test_challenges.py
+++ b/ocdaction/tests/challenges/test_challenges.py
@@ -191,6 +191,17 @@ class ViewsTest(TestCase):
         response = challenge_score_form(request, self.challenge.pk, self.score_card.pk)
         assert response.status_code == 200
 
+    def test_challenge_erase_my_record(self):
+        request = self.factory.get(reverse('challenge-erase-my-record'))
+        request.user = self.user
+        response = challenge_erase_my_record(request)
+        assert response.status_code == 200
+
+    def test_delete_users_challenges(self):
+        request = self.factory.get(reverse('delete-users-challenges'))
+        request.user = self.user
+        response = delete_users_challenges(request)
+        assert response.status_code == 200
 
 # Test the forms
 @pytest.mark.parametrize(


### PR DESCRIPTION
### ISSUE/TICKET NUMBER
https://trello.com/c/FUxJ5BkF/176-delete-data-for-a-user

### Describe the changes
Added functionality to allow a user to delete all their challenges and associated score cards, but keep their account. 
- Does not currently check whether a user has any challenges, but no error is raised if they don't 
- Deleting challenges is done within the challenges app so that the profiles app may be kept for user account handling only
- Basic styling done only

### Screenshots (if appropriate)
<img width="573" alt="screen shot 2018-04-15 at 14 29 26" src="https://user-images.githubusercontent.com/23309660/38778976-9f792920-40b9-11e8-87bf-941e659949ee.png">
<img width="532" alt="screen shot 2018-04-15 at 14 30 24" src="https://user-images.githubusercontent.com/23309660/38778977-9f918b78-40b9-11e8-9de1-79668785781a.png">


### Questions or comments (if any)