### PR TITLE
Amend url pattern for profiles app to remove "users/"

### DIFF
--- a/ocdaction/ocdaction/urls.py
+++ b/ocdaction/ocdaction/urls.py
@@ -33,7 +33,7 @@ urlpatterns = [
         name="index"
     ),
     url(
-        r'^users/',
+        r'',
         include('profiles.urls')
     ),
     url(


### PR DESCRIPTION
### ISSUE/TICKET NUMBER
https://trello.com/c/QvWU1WpB/178-remove-users-from-all-urls-in-the-users-app

### Describe the changes
Shortens the url patterns for the profiles app

### Screenshots (if appropriate)
Affects all urls within the profiles app e.g.:
 - Before ../users/login
 - After ../login

### Questions or comments (if any)
Add "n/a" if nothing to say