### PR TITLE
Changes on registration page: password helptext and age/diagnosis dislaimer

### DIFF
--- a/ocdaction/ocdaction/templates/registration/register.html
+++ b/ocdaction/ocdaction/templates/registration/register.html
@@ -34,9 +34,9 @@
                                 {% endif %}
                             {% endif %}
 
-                        {% if field.name != "password1" %}
+                        {% if field.name == "password1" or "password2" %}
                             {% if field.help_text %}
-                            <p class="helptext">{{ field.help_text|safe }}</p>
+                                <p class="helptext">{{ field.help_text|safe }}</p>
                             {% endif %}
                         {% endif %}
                     </div>

--- a/ocdaction/ocdaction/templates/registration/register.html
+++ b/ocdaction/ocdaction/templates/registration/register.html
@@ -39,11 +39,8 @@
                                 {% endif %}
                             {% endif %}
 
-                        {% if field.name == "password1" or "password2" %}
-                            {% if field.help_text %}
-                                <p class="helptext">{{ field.help_text|safe }}</p>
-                            {% endif %}
-                        {% endif %}
+                        <!-- passwords helptexts -->
+                        <p class="helptext">{{ field.help_text|safe }}</p>
                     </div>
                 {% endfor %}
 

--- a/ocdaction/ocdaction/templates/registration/register.html
+++ b/ocdaction/ocdaction/templates/registration/register.html
@@ -6,6 +6,11 @@
         <section class="container">
             <h1>Register</h1>
             <form method="POST" action="" class="col-xs-12 col-sm-offset-3 col-sm-6 col-md-offset-4 col-md-4 col-lg-offset-4 col-lg-4">
+                <p class="helptext">This app has been designed for teenagers and young adults over the age of 13 who are currently
+                    working with a Cognitive Behavioural Therapist to treat their OCD. If you have not attended treatment for OCD
+                    before and would like to find out more about how you can access it, you can contact our Youth Helpline for
+                    information and support. The details are on the <a class="helptext" href="/contact">contact</a> page.</p>
+                    
                 {% csrf_token %}
 
                 {% if form.non_field_errors %}

--- a/ocdaction/profiles/forms.py
+++ b/ocdaction/profiles/forms.py
@@ -33,6 +33,10 @@ class OCDActionUserRegistrationForm(RegistrationForm):
         label="I agree to the terms and conditions"
     )
 
+    def __init__(self, *args, **kwargs):
+        super(OCDActionUserRegistrationForm, self).__init__(*args, **kwargs)
+        self.fields['password1'].help_text = 'Password must be at least 10 characters.'
+
     class Meta:
         model = OCDActionUser
         fields = ('email', 'password1', 'password2', 'nickname', 'date_birth')


### PR DESCRIPTION
### ISSUE/TICKET NUMBER
https://trello.com/c/0ki73cZf
https://trello.com/c/UUuFVyRe

### Screenshots (if appropriate)
 - After

<img width="470" alt="screen shot 2018-08-18 at 09 16 13" src="https://user-images.githubusercontent.com/5237879/44297323-5ac74300-a2c7-11e8-8afa-2de29d700bd2.png">
