### PR TITLE
Fix ordering of chart legend

### DIFF
--- a/ocdaction/challenges/views.py
+++ b/ocdaction/challenges/views.py
@@ -1,6 +1,8 @@
 import csv
 import json
 
+from collections import OrderedDict
+
 from django.shortcuts import render, redirect, get_object_or_404
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse
@@ -241,7 +243,7 @@ def challenge_results(request, challenge_uuid):
                                                                                  'updated_at').order_by('-updated_at')[:5]
 
     first = True
-    data_sets = {}
+    data_sets = OrderedDict()
     for anxietyscorecard in anxiety_score_cards_for_challenge:
         if first:
             # return the data for the most recent score card


### PR DESCRIPTION
### ISSUE/TICKET NUMBER
Fix bug with chart legend being returned in a random order

### Describe the changes
Chart legend displayed in date order


### Screenshots (if appropriate)
<img width="493" alt="screen shot 2018-12-15 at 16 09 25" src="https://user-images.githubusercontent.com/23309660/50044996-d4a7e700-0083-11e9-84ec-6d4faa15a107.png">

### Questions or comments (if any)
