### PR TITLE
Remove a top back arrow 

### DIFF
--- a/ocdaction/ocdaction/templates/challenge/challenge_results.html
+++ b/ocdaction/ocdaction/templates/challenge/challenge_results.html
@@ -10,14 +10,7 @@
         <section>
             <div class="container">
                 <div class="row">
-                    <div class="col-xs-2 col-md-2">
-                       <span class="backlink">
-                            <a href="{% url 'challenge-list' %}">
-                                <i class="margin-right-5 glyphicon glyphicon-menu-left"></i><span class="backlink__text">Back</span>
-                            </a>
-                        </span>
-                    </div>
-                    <h1 class="col-xs-offset-1 col-md-6">{{ challenge.challenge_name }}</h1>
+                    <h1 class="col-md-12">{{ challenge.challenge_name }}</h1>
                 </div>
             </div>
             <div class="container">


### PR DESCRIPTION
Remove a top back arrow from graph results page as we use 'back to challenges' button instead
