### PR TITLE
Display chart on challenge page

### DIFF
--- a/ocdaction/challenges/templatetags/challenges_tags.py
+++ b/ocdaction/challenges/templatetags/challenges_tags.py
@@ -1,5 +1,4 @@
 from django import template
-from ..models import Challenge, AnxietyScoreCard
 
 register = template.Library()
 

--- a/ocdaction/challenges/views.py
+++ b/ocdaction/challenges/views.py
@@ -12,7 +12,7 @@ from challenges.forms import ChallengeForm, AnxietyScoreCardForm
 
 from profiles.models import OCDActionUser
 
-def get_data_for_challenge_chart(challenge):
+def get_data_for_challenge_chart(challenge, num_challenges):
     """
     :param challenge:
     :return: all chart data for a challenge
@@ -30,7 +30,7 @@ def get_data_for_challenge_chart(challenge):
                                                                                    'anxiety_at_30_min',
                                                                                    'anxiety_at_60_min',
                                                                                    'anxiety_at_120_min',
-                                                                                   'updated_at').order_by('-updated_at')[:5]
+                                                                                   'updated_at').order_by('-updated_at')[:num_challenges]
 
     first = True
     data_sets = OrderedDict()
@@ -141,7 +141,7 @@ def challenge_view(request, challenge_uuid):
     challenge = get_object_or_404(Challenge.objects.filter(user=request.user), uuid=challenge_uuid)
     anxiety_score_cards = AnxietyScoreCard.objects.filter(challenge=challenge).order_by('-id')[:3]
 
-    get_data_for_challenge_chart(challenge)
+    get_data_for_challenge_chart(challenge, 5)
 
     context = {
         'challenge': challenge,
@@ -292,7 +292,7 @@ def challenge_results(request, challenge_uuid):
     """
     challenge = get_object_or_404(Challenge.objects.filter(user=request.user), uuid=challenge_uuid)
 
-    get_data_for_challenge_chart(challenge)
+    get_data_for_challenge_chart(challenge, 5)
 
     context = {
         'challenge': challenge,

--- a/ocdaction/challenges/views.py
+++ b/ocdaction/challenges/views.py
@@ -226,21 +226,25 @@ def challenge_score_form(request, challenge_uuid, score_uuid):
     )
 
 
-@login_required
-def challenge_results(request, challenge_uuid):
+def get_data_for_challenge_chart(challenge):
     """
-    See the results for today's challenges
+    :param challenge:
+    :return: all chart data for a challenge
     """
-    challenge = get_object_or_404(Challenge.objects.filter(user=request.user), uuid=challenge_uuid)
+
+    global latest_scores
+    global latest_anxiety_score_card_label
+    global latest_anxiety_score_card_data
+    global data_sets
 
     anxiety_score_cards_for_challenge = challenge.anxietyscorecard_set.values_list('anxiety_at_0_min',
-                                                                                 'anxiety_at_5_min',
-                                                                                 'anxiety_at_10_min',
-                                                                                 'anxiety_at_15_min',
-                                                                                 'anxiety_at_30_min',
-                                                                                 'anxiety_at_60_min',
-                                                                                 'anxiety_at_120_min',
-                                                                                 'updated_at').order_by('-updated_at')[:5]
+                                                                                   'anxiety_at_5_min',
+                                                                                   'anxiety_at_10_min',
+                                                                                   'anxiety_at_15_min',
+                                                                                   'anxiety_at_30_min',
+                                                                                   'anxiety_at_60_min',
+                                                                                   'anxiety_at_120_min',
+                                                                                   'updated_at').order_by('-updated_at')[:5]
 
     first = True
     data_sets = OrderedDict()
@@ -272,6 +276,15 @@ def challenge_results(request, challenge_uuid):
                 scores.append(i)
             data_sets[anxiety_score_card_date.strftime("%d %b %H:%M")] = json.dumps(scores)
 
+
+@login_required
+def challenge_results(request, challenge_uuid):
+    """
+    See the results for today's challenges
+    """
+    challenge = get_object_or_404(Challenge.objects.filter(user=request.user), uuid=challenge_uuid)
+
+    get_data_for_challenge_chart(challenge)
 
     context = {
         'challenge': challenge,

--- a/ocdaction/challenges/views.py
+++ b/ocdaction/challenges/views.py
@@ -139,13 +139,11 @@ def challenge_view(request, challenge_uuid):
     View a challenge
     """
     challenge = get_object_or_404(Challenge.objects.filter(user=request.user), uuid=challenge_uuid)
-    anxiety_score_cards = AnxietyScoreCard.objects.filter(challenge=challenge).order_by('-id')[:3]
 
     get_data_for_challenge_chart(challenge, 5)
 
     context = {
         'challenge': challenge,
-        'anxiety_score_cards': anxiety_score_cards,
         'latest_scores': latest_scores,
         'latest_anxiety_score_card_data': latest_anxiety_score_card_data,
         'latest_anxiety_score_card_label': latest_anxiety_score_card_label,

--- a/ocdaction/challenges/views.py
+++ b/ocdaction/challenges/views.py
@@ -12,6 +12,56 @@ from challenges.forms import ChallengeForm, AnxietyScoreCardForm
 
 from profiles.models import OCDActionUser
 
+def get_data_for_challenge_chart(challenge):
+    """
+    :param challenge:
+    :return: all chart data for a challenge
+    """
+
+    global latest_scores
+    global latest_anxiety_score_card_label
+    global latest_anxiety_score_card_data
+    global data_sets
+
+    anxiety_score_cards_for_challenge = challenge.anxietyscorecard_set.values_list('anxiety_at_0_min',
+                                                                                   'anxiety_at_5_min',
+                                                                                   'anxiety_at_10_min',
+                                                                                   'anxiety_at_15_min',
+                                                                                   'anxiety_at_30_min',
+                                                                                   'anxiety_at_60_min',
+                                                                                   'anxiety_at_120_min',
+                                                                                   'updated_at').order_by('-updated_at')[:5]
+
+    first = True
+    data_sets = OrderedDict()
+    for anxietyscorecard in anxiety_score_cards_for_challenge:
+        if first:
+            # return the data for the most recent score card
+            first = False
+            latest_anxietyscorecard_as_list = list(anxietyscorecard)
+            latest_anxiety_score_card_date = latest_anxietyscorecard_as_list.pop()
+            latest_scores = []
+            for i in latest_anxietyscorecard_as_list:
+                try:
+                    i = int(i)
+                except:
+                    i = None
+                latest_scores.append(i)
+            latest_anxiety_score_card_data = json.dumps(latest_scores)
+            latest_anxiety_score_card_label = latest_anxiety_score_card_date.strftime("%d %b")
+        else:
+            # return the data for the remaining score cards
+            anxietyscorecard_as_list = list(anxietyscorecard)
+            anxiety_score_card_date = anxietyscorecard_as_list.pop()
+            scores = []
+            for i in anxietyscorecard_as_list:
+                try:
+                    i = int(i)
+                except:
+                    i = None
+                scores.append(i)
+            data_sets[anxiety_score_card_date.strftime("%d %b %H:%M")] = json.dumps(scores)
+
 
 @login_required
 def challenge_list(request):
@@ -91,7 +141,16 @@ def challenge_view(request, challenge_uuid):
     challenge = get_object_or_404(Challenge.objects.filter(user=request.user), uuid=challenge_uuid)
     anxiety_score_cards = AnxietyScoreCard.objects.filter(challenge=challenge).order_by('-id')[:3]
 
-    context = {'challenge': challenge, 'anxiety_score_cards': anxiety_score_cards}
+    get_data_for_challenge_chart(challenge)
+
+    context = {
+        'challenge': challenge,
+        'anxiety_score_cards': anxiety_score_cards,
+        'latest_scores': latest_scores,
+        'latest_anxiety_score_card_data': latest_anxiety_score_card_data,
+        'latest_anxiety_score_card_label': latest_anxiety_score_card_label,
+        'data_sets': data_sets
+    }
 
     return render(request, 'challenge/challenge_view.html', context)
 
@@ -224,57 +283,6 @@ def challenge_score_form(request, challenge_uuid, score_uuid):
         'challenge/challenge_score_form.html',
         context
     )
-
-
-def get_data_for_challenge_chart(challenge):
-    """
-    :param challenge:
-    :return: all chart data for a challenge
-    """
-
-    global latest_scores
-    global latest_anxiety_score_card_label
-    global latest_anxiety_score_card_data
-    global data_sets
-
-    anxiety_score_cards_for_challenge = challenge.anxietyscorecard_set.values_list('anxiety_at_0_min',
-                                                                                   'anxiety_at_5_min',
-                                                                                   'anxiety_at_10_min',
-                                                                                   'anxiety_at_15_min',
-                                                                                   'anxiety_at_30_min',
-                                                                                   'anxiety_at_60_min',
-                                                                                   'anxiety_at_120_min',
-                                                                                   'updated_at').order_by('-updated_at')[:5]
-
-    first = True
-    data_sets = OrderedDict()
-    for anxietyscorecard in anxiety_score_cards_for_challenge:
-        if first:
-            # return the data for the most recent score card
-            first = False
-            latest_anxietyscorecard_as_list = list(anxietyscorecard)
-            latest_anxiety_score_card_date = latest_anxietyscorecard_as_list.pop()
-            latest_scores = []
-            for i in latest_anxietyscorecard_as_list:
-                try:
-                    i = int(i)
-                except:
-                    i = None
-                latest_scores.append(i)
-            latest_anxiety_score_card_data = json.dumps(latest_scores)
-            latest_anxiety_score_card_label = latest_anxiety_score_card_date.strftime("%d %b")
-        else:
-            # return the data for the remaining score cards
-            anxietyscorecard_as_list = list(anxietyscorecard)
-            anxiety_score_card_date = anxietyscorecard_as_list.pop()
-            scores = []
-            for i in anxietyscorecard_as_list:
-                try:
-                    i = int(i)
-                except:
-                    i = None
-                scores.append(i)
-            data_sets[anxiety_score_card_date.strftime("%d %b %H:%M")] = json.dumps(scores)
 
 
 @login_required

--- a/ocdaction/ocdaction/templates/challenge/challenge_chart.html
+++ b/ocdaction/ocdaction/templates/challenge/challenge_chart.html
@@ -1,0 +1,97 @@
+{% extends "layout.html" %}
+
+{% load static %}
+{% load challenges_tags %}
+
+{% block extrahead %}
+
+    <section>
+        <div class="container">
+            <div class="row">
+                <h1 class="col-md-12">{{ challenge.challenge_name }}</h1>
+            </div>
+        </div>
+        <div class="container">
+            <div class="row">
+                <div class="col-xs-2 col-md-2">
+                    <br>
+                </div>
+            </div>
+        </div>
+        <div class="text-center col-xs-12 col-md-4 col-md-offset-4"><canvas id="anxietyScoreChart" width="50" height="30"></canvas></div>
+    </section>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.4.0/Chart.min.js"></script>
+    <script type="text/javascript">
+
+    var ctx = "anxietyScoreChart";
+    var anxietyScoreChart = new Chart(ctx, {
+        type: 'line',
+        data: {
+            labels: ['0', '5', '10', '15', '30', '60', '120'],
+            datasets: [{
+                label: '{{ latest_anxiety_score_card_label }}',
+                borderColor: 'rgb(0, 0, 0)',
+                pointStyle: 'circle',
+                pointBackgroundColor: 'rgb(0, 0, 0)',
+                pointBorderColor: 'rgb(0, 0, 0)',
+                fill: false,
+                radius: 5,
+                data: {{ latest_anxiety_score_card_data }},
+            }]
+        },
+        options: {
+            scales: {
+               xAxes: [{
+                   ticks: {
+                       min: 0,
+                       max: 120
+                   }
+               }],
+               yAxes: [{
+                   ticks: {
+                       min: 0,
+                       max: 10
+                   }
+               }]
+            },
+            legend: {
+                position: 'bottom',
+                labels: {
+                    usePointStyle: true
+                }
+            },
+            elements: {
+                line: {
+                    tension: 0, // disables bezier curves
+                }
+            }
+        }
+    });
+
+    var dynamicColors = function() {
+        var r = Math.floor(Math.random() * 255);
+        var g = Math.floor(Math.random() * 255);
+        var b = Math.floor(Math.random() * 255);
+        return "rgb(" + r + "," + g + "," + b + ")";
+     };
+
+    function addData(chart, label, color, data) {
+         chart.data.datasets.push({
+             label: label,
+             borderColor: color,
+             pointStyle: 'circle',
+             pointBackgroundColor: color,
+             pointBorderColor: color,
+             fill: false,
+             radius: 5,
+             data: data
+        });
+        chart.update();
+    }
+
+    {% for label, data in data_sets.items %}
+        addData(anxietyScoreChart, '{{ label|slice:":-6" }}', dynamicColors(), {{ data }})
+    {% endfor %}
+
+    </script>
+{% endblock %}

--- a/ocdaction/ocdaction/templates/challenge/challenge_chart.html
+++ b/ocdaction/ocdaction/templates/challenge/challenge_chart.html
@@ -5,6 +5,8 @@
 
 {% block extrahead %}
 
+{% if data_sets %}
+
     <section>
         <div class="container">
             <div class="row">
@@ -94,4 +96,7 @@
     {% endfor %}
 
     </script>
+
+{% endif %}
+
 {% endblock %}

--- a/ocdaction/ocdaction/templates/challenge/challenge_chart.html
+++ b/ocdaction/ocdaction/templates/challenge/challenge_chart.html
@@ -8,18 +8,6 @@
 {% if data_sets %}
 
     <section>
-        <div class="container">
-            <div class="row">
-                <h1 class="col-md-12">{{ challenge.challenge_name }}</h1>
-            </div>
-        </div>
-        <div class="container">
-            <div class="row">
-                <div class="col-xs-2 col-md-2">
-                    <br>
-                </div>
-            </div>
-        </div>
         <div class="text-center col-xs-12 col-md-4 col-md-offset-4"><canvas id="anxietyScoreChart" width="50" height="30"></canvas></div>
     </section>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.4.0/Chart.min.js"></script>

--- a/ocdaction/ocdaction/templates/challenge/challenge_results.html
+++ b/ocdaction/ocdaction/templates/challenge/challenge_results.html
@@ -1,145 +1,53 @@
-{% extends "layout.html" %}
+{% extends "challenge/challenge_chart.html" %}
 
 {% block title %}Challenge Results{% endblock %}
 
 {% load static %}
 {% load challenges_tags %}
 
-    {% block extrahead %}
-
-        <section>
-            <div class="container">
-                <div class="row">
-                    <h1 class="col-md-12">{{ challenge.challenge_name }}</h1>
+{% block main %}
+    <section>
+        <div class="challenge-summary ibox-content text-center col-xs-12 col-md-4 col-md-offset-4">
+            <h3 class="font-bold margin-bottom-0">Today's anxiety levels:</h3>
+            <table class="challenge-summary--table">
+                <tbody>
+                    <tr>
+                        <td>Initial anxiety level:</td>
+                        <td>{% render_anxiety_level latest_scores.0 %}</td>
+                    </tr>
+                    <tr>
+                        <td>After 5mins:</td>
+                        <td>{% render_anxiety_level latest_scores.1 %}</td>
+                    </tr>
+                    <tr>
+                        <td>After 10mins:</td>
+                        <td>{% render_anxiety_level latest_scores.2 %}</td>
+                    </tr>
+                    <tr>
+                        <td>After 15mins:</td>
+                        <td>{% render_anxiety_level latest_scores.3 %}</td>
+                    </tr>
+                    <tr>
+                        <td>After 30mins:</td>
+                        <td>{% render_anxiety_level latest_scores.4 %}</td>
+                    </tr>
+                    <tr>
+                        <td>After 60mins:</td>
+                        <td>{% render_anxiety_level latest_scores.5 %}</td>
+                    </tr>
+                    <tr>
+                        <td>After 120mins:</td>
+                        <td>{% render_anxiety_level latest_scores.6 %}</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+        <div class="container">
+            <div class="row text-center">
+                <div class="col-xs-12 col-md-4 col-md-offset-4">
+                    <a class="button button--primary" href="{% url 'challenge-list' %}">Back to challenges</a>
                 </div>
             </div>
-            <div class="container">
-                <div class="row">
-                    <div class="col-xs-2 col-md-2">
-                        <br>
-                    </div>
-                </div>
-            </div>
-            <div class="text-center col-xs-12 col-md-4 col-md-offset-4"><canvas id="anxietyScoreChart" width="50" height="30"></canvas></div>
-        </section>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.4.0/Chart.min.js"></script>
-        <script type="text/javascript">
-
-        var ctx = "anxietyScoreChart";
-        var anxietyScoreChart = new Chart(ctx, {
-            type: 'line',
-            data: {
-                labels: ['0', '5', '10', '15', '30', '60', '120'],
-                datasets: [{
-                    label: '{{ latest_anxiety_score_card_label }}',
-                    borderColor: 'rgb(0, 0, 0)',
-                    pointStyle: 'circle',
-                    pointBackgroundColor: 'rgb(0, 0, 0)',
-                    pointBorderColor: 'rgb(0, 0, 0)',
-                    fill: false,
-                    radius: 5,
-                    data: {{ latest_anxiety_score_card_data }},
-                }]
-            },
-            options: {
-                scales: {
-                   xAxes: [{
-                       ticks: {
-                           min: 0,
-                           max: 120
-                       }
-                   }],
-                   yAxes: [{
-                       ticks: {
-                           min: 0,
-                           max: 10
-                       }
-                   }]
-                },
-                legend: {
-                    position: 'bottom',
-                    labels: {
-                        usePointStyle: true
-                    }
-                },
-                elements: {
-                    line: {
-                        tension: 0, // disables bezier curves
-                    }
-                }
-            }
-        });
-
-        var dynamicColors = function() {
-            var r = Math.floor(Math.random() * 255);
-            var g = Math.floor(Math.random() * 255);
-            var b = Math.floor(Math.random() * 255);
-            return "rgb(" + r + "," + g + "," + b + ")";
-         };
-
-        function addData(chart, label, color, data) {
-             chart.data.datasets.push({
-                 label: label,
-                 borderColor: color,
-                 pointStyle: 'circle',
-                 pointBackgroundColor: color,
-                 pointBorderColor: color,
-                 fill: false,
-                 radius: 5,
-                 data: data
-            });
-            chart.update();
-        }
-
-        {% for label, data in data_sets.items %}
-            addData(anxietyScoreChart, '{{ label|slice:":-6" }}', dynamicColors(), {{ data }})
-        {% endfor %}
-
-        </script>
-    {% endblock %}
-    {% block main %}
-        <section>
-            <div class="challenge-summary ibox-content text-center col-xs-12 col-md-4 col-md-offset-4">
-                <h3 class="font-bold margin-bottom-0">Today's anxiety levels:</h3>
-                <table class="challenge-summary--table">
-                    <tbody>
-                        <tr>
-                            <td>Initial anxiety level:</td>
-                            <td>{% render_anxiety_level latest_scores.0 %}</td>
-                        </tr>
-                        <tr>
-                            <td>After 5mins:</td>
-                            <td>{% render_anxiety_level latest_scores.1 %}</td>
-                        </tr>
-                        <tr>
-                            <td>After 10mins:</td>
-                            <td>{% render_anxiety_level latest_scores.2 %}</td>
-                        </tr>
-                        <tr>
-                            <td>After 15mins:</td>
-                            <td>{% render_anxiety_level latest_scores.3 %}</td>
-                        </tr>
-                        <tr>
-                            <td>After 30mins:</td>
-                            <td>{% render_anxiety_level latest_scores.4 %}</td>
-                        </tr>
-                        <tr>
-                            <td>After 60mins:</td>
-                            <td>{% render_anxiety_level latest_scores.5 %}</td>
-                        </tr>
-                        <tr>
-                            <td>After 120mins:</td>
-                            <td>{% render_anxiety_level latest_scores.6 %}</td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-            <div class="container">
-                <div class="row text-center">
-                    <div class="col-xs-12 col-md-4 col-md-offset-4">
-                        <a class="button button--primary" href="{% url 'challenge-list' %}">Back to challenges</a>
-                    </div>
-                </div>
-            </div>
-        </section>
-    {% endblock %}
+        </div>
+    </section>
+{% endblock %}

--- a/ocdaction/ocdaction/templates/challenge/challenge_results.html
+++ b/ocdaction/ocdaction/templates/challenge/challenge_results.html
@@ -5,7 +5,7 @@
 {% load static %}
 {% load challenges_tags %}
 
-{% block main %}
+{% block results %}
     <section>
         <div class="challenge-summary ibox-content text-center col-xs-12 col-md-4 col-md-offset-4">
             <h3 class="font-bold margin-bottom-0">Today's anxiety levels:</h3>

--- a/ocdaction/ocdaction/templates/challenge/challenge_results.html
+++ b/ocdaction/ocdaction/templates/challenge/challenge_results.html
@@ -5,6 +5,12 @@
 {% load static %}
 {% load challenges_tags %}
 
+{% block charttitle %}
+    <section>
+        <h1 class="col-md-12">{{ challenge.challenge_name }}</h1>
+    </section>
+{% endblock %}
+
 {% block results %}
     <section>
         <div class="challenge-summary ibox-content text-center col-xs-12 col-md-4 col-md-offset-4">

--- a/ocdaction/ocdaction/templates/challenge/challenge_view.html
+++ b/ocdaction/ocdaction/templates/challenge/challenge_view.html
@@ -1,4 +1,4 @@
-{% extends "layout.html" %}
+{% extends "challenge/challenge_chart.html" %}
 
 {% block title %}Challenge: {{ challenge.challenge_name }}{% endblock %} 
 

--- a/ocdaction/ocdaction/templates/challenge/challenge_view.html
+++ b/ocdaction/ocdaction/templates/challenge/challenge_view.html
@@ -3,7 +3,6 @@
 {% block title %}Challenge: {{ challenge.challenge_name }}{% endblock %} 
 
 {% load static %}
-{% load challenges_tags %}
 
 {% block main %}
     <section class="section{% if anxiety_score_cards %}--custom {% endif %}">
@@ -49,70 +48,12 @@
         </div>
     </section>
 
-    {% if anxiety_score_cards %}
-        {% if challenge.is_archived %}
-            <div class="challenge-summary challenge-summary--archive ibox-content col-xs-12 col-md-4 col-md-offset-4">
-        {% else %}
-            <div class="challenge-summary col-xs-12 col-md-7 col-md-offset-2">
-                <div class="row"><hr class="col-md-6 col-md-offset-3"></div>
-        {% endif %} 
+    {% if data_sets %}
+        <div class="challenge-summary col-xs-12 col-md-7 col-md-offset-2">
+            <div class="row"><hr class="col-md-6 col-md-offset-3"></div>
             <div class="row">
                 <p>Your exposures for this challenge</p>
             </div>
-            <table class="challenge-summary--table">
-                <thead>
-                    <tr>
-                        <th></th>
-                        <th><div>Most</div><div>recent</div></th>
-                        <th></th>
-                        <th></th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>Anxiety at 0min:</td>
-                        {% for card in anxiety_score_cards %}
-                            <td>{% render_anxiety_level card.anxiety_at_0_min %}</td>
-                        {% endfor %}
-                    </tr>
-                    <tr>
-                        <td>Anxiety at 5min:</td>
-                        {% for card in anxiety_score_cards %}
-                            <td>{% render_anxiety_level card.anxiety_at_5_min %}</td>
-                        {% endfor %}
-                    </tr>
-                    <tr>
-                        <td>Anxiety at 10min:</td>
-                        {% for card in anxiety_score_cards %}
-                            <td>{% render_anxiety_level card.anxiety_at_10_min %}</td>
-                        {% endfor %}
-                    </tr>
-                    <tr>
-                        <td>Anxiety at 15min:</td>
-                        {% for card in anxiety_score_cards %}
-                            <td>{% render_anxiety_level card.anxiety_at_15_min %}</td>
-                        {% endfor %}
-                    </tr>
-                    <tr>
-                        <td>Anxiety at 30min:</td>
-                        {% for card in anxiety_score_cards %}
-                            <td>{% render_anxiety_level card.anxiety_at_30_min %}</td>
-                        {% endfor %}
-                    </tr>
-                    <tr>
-                        <td>Anxiety at 60min:</td>
-                        {% for card in anxiety_score_cards %}
-                            <td>{% render_anxiety_level card.anxiety_at_60_min %}</td>
-                        {% endfor %}
-                    </tr>
-                    <tr>
-                        <td>Anxiety at 120min:</td>
-                        {% for card in anxiety_score_cards %}
-                            <td>{% render_anxiety_level card.anxiety_at_120_min %}</td>
-                        {% endfor %}
-                    </tr>
-                </tbody>
-            </table>
         </div>
     {% endif %}
 

--- a/ocdaction/ocdaction/templates/layout.html
+++ b/ocdaction/ocdaction/templates/layout.html
@@ -48,6 +48,8 @@
 		</header>
         {% block main %}
         {% endblock %}
+        {% block charttitle %}
+        {% endblock %}
         {% block extrahead %}
         {% endblock %}
 	    {% block results %}

--- a/ocdaction/ocdaction/templates/layout.html
+++ b/ocdaction/ocdaction/templates/layout.html
@@ -46,9 +46,11 @@
 				</nav>
 			</div>
 		</header>
+        {% block main %}
+        {% endblock %}
         {% block extrahead %}
         {% endblock %}
-	    {% block main %}
+	    {% block results %}
 	    {% endblock %}
 	</div>
 


### PR DESCRIPTION
### ISSUE/TICKET NUMBER
Add graphs results to Challenge page

### Describe the changes
Display the challenge results chart on the challenge view page and on the archived challenge page.  Refactoring done to avoid duplicating code.

### Screenshots (if appropriate)
responsive/mobile:
<img width="356" alt="screenshot 2019-01-05 at 17 08 09" src="https://user-images.githubusercontent.com/23309660/50727028-f2a9ba00-110c-11e9-8c66-7ca3b9a4bd9e.png">
desktop
<img width="539" alt="screenshot 2019-01-05 at 17 09 59" src="https://user-images.githubusercontent.com/23309660/50727032-f9383180-110c-11e9-993c-b7725ba5f6c4.png">


### Questions or comments (if any)
Needs some styling work